### PR TITLE
feat(bin): add --repo flag to git-commit and git-cleanup wrappers

### DIFF
--- a/bin/git-cleanup-merged-branch.sh
+++ b/bin/git-cleanup-merged-branch.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 # Git cleanup script - checkout base branch, pull latest, delete merged feature branch
-# Usage: git-cleanup-merged-branch.sh [feature-branch] [base-branch]
+# Usage: git-cleanup-merged-branch.sh [--repo DIR] [feature-branch] [base-branch]
 #   If no branches specified, uses current branch as feature and finds its base
+#   --repo DIR  Run git in repository DIR (avoids a leading `cd`, which would
+#               break the Bash(~/.claude/bin/*) permission match)
 
 set -e  # Exit on error
+
+# Parse an optional --repo flag from the front of the argument list, then cd in
+# BEFORE any git command (including the `git branch --show-current` default).
+if [ "${1:-}" = "--repo" ]; then
+    REPO_DIR="$2"
+    shift 2
+    cd "$REPO_DIR" || { echo "Error: cannot cd into repo '$REPO_DIR'" >&2; exit 1; }
+fi
 
 FEATURE_BRANCH="${1:-$(git branch --show-current)}"
 BASE_BRANCH="${2:-}"
@@ -28,7 +38,7 @@ if [ -z "$BASE_BRANCH" ]; then
         # Fallback: check common base branches
         for candidate in develop master main; do
             if git show-ref --verify --quiet refs/heads/$candidate; then
-                if git merge-base --is-ancestor $candidate $FEATURE_BRANCH 2>/dev/null; then
+                if git merge-base --is-ancestor "$candidate" "$FEATURE_BRANCH" 2>/dev/null; then
                     BASE_BRANCH=$candidate
                     break
                 fi
@@ -46,13 +56,13 @@ fi
 echo "Base branch: $BASE_BRANCH"
 
 # Verify feature branch exists
-if ! git show-ref --verify --quiet refs/heads/$FEATURE_BRANCH; then
+if ! git show-ref --verify --quiet refs/heads/"$FEATURE_BRANCH"; then
     echo -e "${RED}Error: Branch '$FEATURE_BRANCH' does not exist${NC}"
     exit 1
 fi
 
 # Verify base branch exists
-if ! git show-ref --verify --quiet refs/heads/$BASE_BRANCH; then
+if ! git show-ref --verify --quiet refs/heads/"$BASE_BRANCH"; then
     echo -e "${RED}Error: Base branch '$BASE_BRANCH' does not exist${NC}"
     exit 1
 fi
@@ -75,7 +85,7 @@ fi
 
 # Step 1: Checkout base branch
 echo -e "\n${GREEN}Step 1: Checking out $BASE_BRANCH${NC}"
-git checkout $BASE_BRANCH
+git checkout "$BASE_BRANCH"
 
 # Step 2: Fetch latest changes and prune stale remote-tracking branches
 echo -e "\n${GREEN}Step 2: Fetching latest changes${NC}"
@@ -83,23 +93,23 @@ git fetch --prune origin
 
 # Step 3: Pull latest changes
 echo -e "\n${GREEN}Step 3: Pulling latest $BASE_BRANCH${NC}"
-git pull --prune origin $BASE_BRANCH
+git pull --prune origin "$BASE_BRANCH"
 
 # Step 4: Delete feature branch (only if fully merged)
 echo -e "\n${GREEN}Step 4: Deleting merged feature branch $FEATURE_BRANCH${NC}"
 
 # Check if feature branch is fully merged
-if git branch --merged $BASE_BRANCH | grep -q "^[* ]*$FEATURE_BRANCH$"; then
-    git branch -d $FEATURE_BRANCH
+if git branch --merged "$BASE_BRANCH" | grep -q "^[* ]*$FEATURE_BRANCH$"; then
+    git branch -d "$FEATURE_BRANCH"
     echo -e "${GREEN}✓ Successfully deleted local branch '$FEATURE_BRANCH'${NC}"
 
     # Try to delete remote branch if it exists
-    if git ls-remote --exit-code --heads origin $FEATURE_BRANCH &>/dev/null; then
+    if git ls-remote --exit-code --heads origin "$FEATURE_BRANCH" &>/dev/null; then
         echo -e "\n${YELLOW}Remote branch 'origin/$FEATURE_BRANCH' still exists${NC}"
         read -p "Delete remote branch? (y/N) " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git push origin --delete $FEATURE_BRANCH
+            git push origin --delete "$FEATURE_BRANCH"
             echo -e "${GREEN}✓ Successfully deleted remote branch 'origin/$FEATURE_BRANCH'${NC}"
         fi
     fi

--- a/bin/git-commit.sh
+++ b/bin/git-commit.sh
@@ -13,12 +13,15 @@
 #   --file F   Read commit message from file F
 #   --stdin    Read commit message from stdin
 #   --amend    Amend the previous commit (use with caution)
+#   --repo D   Run git in repository directory D (avoids a leading `cd`, which
+#              would break the Bash(~/.claude/bin/*) permission match)
 
 set -euo pipefail
 
 AMEND=""
 FROM_STDIN=""
 FROM_FILE=""
+REPO_DIR=""
 MSG_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -31,6 +34,10 @@ while [[ $# -gt 0 ]]; do
             FROM_FILE="$2"
             shift 2
             ;;
+        --repo)
+            REPO_DIR="$2"
+            shift 2
+            ;;
         --amend)
             AMEND="--amend"
             shift
@@ -41,6 +48,12 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Switch into the repository if requested, so the caller need not prefix the
+# command with `cd` (which would break the permission allow-match).
+if [[ -n "$REPO_DIR" ]]; then
+    cd "$REPO_DIR" || { echo "Error: cannot cd into repo '$REPO_DIR'." >&2; exit 1; }
+fi
 
 # --file: use the file directly, no temp file needed
 if [[ -n "$FROM_FILE" ]]; then


### PR DESCRIPTION
## Summary

Adds a `--repo <dir>` flag to both `git-commit.sh` and `git-cleanup-merged-branch.sh`.

Both wrappers relied on git's cwd auto-discovery. When the Bash cwd had drifted elsewhere (e.g. a prior `cd /tmp` for another tool), they failed with `not a git repository`. The instinctive fix — prefixing the call with `GIT_DIR=... GIT_WORK_TREE=... ~/.claude/bin/...` — **breaks the `Bash(~/.claude/bin/*)` permission allow-match**, because the first word becomes the env assignment, not the script, triggering a permission prompt on every call.

The flag lets callers point the wrapper at a repo without a `cd` or env-var prefix:

```
git-commit.sh --repo /path/to/repo --file msg.txt
git-cleanup-merged-branch.sh --repo /path/to/repo <feature> <base>
```

In `git-cleanup` the flag is parsed and the `cd` happens **before** the `git branch --show-current` default, so auto-detection sees the right repo.

## Also

- Quote the branch-name expansions flagged by shellcheck (SC2086) in `git-cleanup`. Both scripts now pass `shellcheck` clean.

## Verification

- `shellcheck` on both scripts: clean (exit 0).
- Smoke-tested `git-commit.sh --repo <dir>` from an unrelated cwd: commits into the target repo, exit 0.
- Dogfooded: this branch's own commit was made with `git-commit.sh --repo ...` from a different project's cwd, prompt-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
