### PR TITLE
feat(bin): add git-diff-base.sh + --repo flag

### DIFF
--- a/bin/git-diff-base.sh
+++ b/bin/git-diff-base.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Print files (or full diff) changed on the current branch vs its base branch.
+# Resolves the merge-base internally so callers never need $(...) substitution
+# — which the Bash permission matcher blocks. Matches Bash(~/.claude/bin/*).
+#
+# Usage:
+#   git-diff-base.sh                 # names of changed files vs base (default: main)
+#   git-diff-base.sh --base develop  # vs a specific base branch
+#   git-diff-base.sh --stat          # diffstat instead of names
+#   git-diff-base.sh --patch         # full patch
+#   git-diff-base.sh --repo DIR ...  # run git in repository DIR (avoids a leading
+#                                    # `cd`, which would break the allow-match)
+set -euo pipefail
+
+base="main"
+mode="--name-only"
+repo=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) base="$2"; shift 2 ;;
+    --repo) repo="$2"; shift 2 ;;
+    --stat)  mode="--stat";  shift ;;
+    --patch) mode="";        shift ;;
+    --name-only) mode="--name-only"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Switch into the repository if requested, before any git command.
+if [[ -n "$repo" ]]; then
+  cd "$repo" || { echo "Error: cannot cd into repo '$repo'" >&2; exit 1; }
+fi
+
+mb="$(git merge-base HEAD "$base")"
+# shellcheck disable=SC2086  # $mode is intentionally word-split (may be empty)
+git diff $mode "$mb"..HEAD


### PR DESCRIPTION
## Summary

Commits `git-diff-base.sh`, which was sitting untracked in `bin/`, and adds a `--repo` flag to it for consistency with the other git wrappers.

`git-diff-base.sh` prints the files (or full diff) changed on the current branch vs its base branch. It resolves the merge-base internally, so callers never need `$(...)` command substitution — which the Bash permission matcher blocks.

```
git-diff-base.sh                 # names of changed files vs base (default: main)
git-diff-base.sh --base develop  # vs a specific base branch
git-diff-base.sh --stat          # diffstat instead of names
git-diff-base.sh --patch         # full patch
git-diff-base.sh --repo DIR ...  # run git in repository DIR
```

The `--repo <dir>` flag (matching `git-commit.sh` / `git-cleanup-merged-branch.sh` in #6) cd's into the repo before any git command, so the wrapper works when the Bash cwd has drifted elsewhere without a `cd`/env-var prefix that would break the `Bash(~/.claude/bin/*)` allow-match.

## Verification

- `shellcheck`: clean (exit 0).
- Smoke-tested `git-diff-base.sh --repo <dir> --base main` from an unrelated cwd: correctly lists the branch's changed files, exit 0.

## Relation to #6

Same `--repo` motivation as #6 (which adds the flag to `git-commit.sh` and `git-cleanup-merged-branch.sh`); kept as a separate PR because this one also introduces a previously-untracked script. Independent of #6 — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
