### PR TITLE
fix(bin): prefer develop/master/main as base branch over feature branches

### DIFF
--- a/bin/git-find-base-branch
+++ b/bin/git-find-base-branch
@@ -1,20 +1,37 @@
 #!/bin/bash
-# Find the base branch by determining which branch has the most recent merge base
-# with the current branch. This identifies which branch the current branch was
-# most recently branched from.
+# Find the base branch a feature branch should target / was branched from.
+#
+# Strategy (in order):
+#   1. Prefer a known integration branch (develop > master > main) when it is an
+#      ancestor of the current branch. A feature branch cut from develop will
+#      have develop as an ancestor, so this returns the real integration target
+#      instead of some unrelated long-lived feature branch that happens to share
+#      a more recent merge base.
+#   2. Fallback: the ancestor branch with the most recent merge base with the
+#      current branch (original heuristic) — covers repos without a
+#      develop/master/main branch.
+#   3. Last resort: first existing develop/master/main, even if not an ancestor.
 
 current=$(git branch --show-current)
+
+# 1. Prefer a known integration branch that is an ancestor of current.
+#    Skip current itself so `develop` returns `master`, not `develop`.
+for branch in develop master main; do
+    [ "$branch" = "$current" ] && continue
+    git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null || continue
+    if git merge-base --is-ancestor "$branch" "$current" 2>/dev/null; then
+        echo "$branch"
+        exit 0
+    fi
+done
+
+# 2. Fallback: ancestor branch with the most recent merge base with current.
 best=""
 best_date=0
-
-# Check all local branches except current
 for branch in $(git for-each-ref --format='%(refname:short)' refs/heads/ | grep -v "^${current}$"); do
-    # Check if branch is ancestor of current
     if git merge-base --is-ancestor "$branch" "$current" 2>/dev/null; then
         merge_base=$(git merge-base "$branch" "$current")
         commit_date=$(git show -s --format=%ct "$merge_base")
-
-        # Track the branch with most recent merge base
         if [ "$commit_date" -gt "$best_date" ]; then
             best_date=$commit_date
             best=$branch
@@ -24,12 +41,14 @@ done
 
 if [ -n "$best" ]; then
     echo "$best"
-else
-    # Fallback to common defaults
-    for branch in develop master main; do
-        if git show-ref --verify --quiet refs/heads/$branch 2>/dev/null; then
-            echo "$branch"
-            exit 0
-        fi
-    done
+    exit 0
 fi
+
+# 3. Last resort: first existing default branch, even if not an ancestor.
+for branch in develop master main; do
+    [ "$branch" = "$current" ] && continue
+    if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+        echo "$branch"
+        exit 0
+    fi
+done


### PR DESCRIPTION
## Probleem

`git-find-base-branch` gebruikte een "most recent merge base"-heuristiek: het koos de ancestor-branch met de nieuwste merge-base met de huidige branch. Zodra er een langlopende feature-branch náást `develop` bestond, won die feature-branch — dus een verse branch van develop rapporteerde een ongerelateerde feature-branch als base. `/cleanup` checkoutte vervolgens de verkeerde branch en weigerde de gemergede branch te verwijderen.

Concreet gezien in PAM: vanaf develop gaf het script `issue-2214-squid-guard-comment` terug i.p.v. `master`, en `/cleanup` liep daardoor vast.

## Oplossing

Nieuwe resolutie-volgorde:

1. **Prefereer een bekende integratiebranch** (`develop` > `master` > `main`) wanneer die een ancestor is van de huidige branch — het echte target.
2. **Fallback** naar de originele most-recent-merge-base heuristiek (repos zonder develop/master/main).
3. **Last resort**: eerste bestaande default-branch, ook als die geen ancestor is.

De huidige branch wordt overgeslagen in stap 1 en 3, dus vanaf `develop` → `master`, en vanaf een feature-branch van develop → `develop`.

## Verificatie

Getest in de PAM-repo:

| Vanaf | Verwacht | Resultaat |
|-------|----------|-----------|
| `develop` | `master` | ✅ `master` |
| feature-branch van develop | `develop` | ✅ `develop` (de case die eerder misging) |

`shellcheck` schoon.
