### PR TITLE
implement skills: replace $() and polling constructs with bin/ wrappers

### DIFF
--- a/bin/git-diff-base.sh
+++ b/bin/git-diff-base.sh
@@ -4,15 +4,20 @@
 # — which the Bash permission matcher blocks. Matches Bash(~/.claude/bin/*).
 #
 # Usage:
-#   git-diff-base.sh                 # names of changed files vs base (default: main)
-#   git-diff-base.sh --base develop  # vs a specific base branch
+#   git-diff-base.sh                 # names of changed files vs auto-detected base
+#   git-diff-base.sh develop         # vs a specific base branch (positional)
+#   git-diff-base.sh --base develop  # vs a specific base branch (flag form)
 #   git-diff-base.sh --stat          # diffstat instead of names
 #   git-diff-base.sh --patch         # full patch
 #   git-diff-base.sh --repo DIR ...  # run git in repository DIR (avoids a leading
 #                                    # `cd`, which would break the allow-match)
+#
+# When no base is given (positional or --base), it is resolved via
+# git-find-base-branch. Works from a detached HEAD or a branch with no
+# upstream, since resolution only inspects local branches.
 set -euo pipefail
 
-base="main"
+base=""
 mode="--name-only"
 repo=""
 while [[ $# -gt 0 ]]; do
@@ -22,13 +27,19 @@ while [[ $# -gt 0 ]]; do
     --stat)  mode="--stat";  shift ;;
     --patch) mode="";        shift ;;
     --name-only) mode="--name-only"; shift ;;
-    *) echo "unknown arg: $1" >&2; exit 2 ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *) base="$1"; shift ;;
   esac
 done
 
 # Switch into the repository if requested, before any git command.
 if [[ -n "$repo" ]]; then
   cd "$repo" || { echo "Error: cannot cd into repo '$repo'" >&2; exit 1; }
+fi
+
+if [[ -z "$base" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  base="$("$script_dir/git-find-base-branch")" || { echo "Error: could not auto-detect base branch — pass one explicitly" >&2; exit 1; }
 fi
 
 mb="$(git merge-base HEAD "$base")"

--- a/bin/wait-for-healthy.sh
+++ b/bin/wait-for-healthy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Poll a Docker container's health status until healthy or timeout.
+# Replaces ad-hoc `until docker inspect ...; do sleep N; done` loops, whose
+# shell keywords (`until`) and `sleep` first-token never match a Bash
+# permission allowlist. Matches Bash(~/.claude/bin/*).
+#
+# Usage: wait-for-healthy.sh <container> [--timeout SECS] [--interval SECS]
+# Example: wait-for-healthy.sh pam_api --timeout 60
+#
+# Exit codes:
+#   0  container reached "healthy"
+#   1  timed out before becoming healthy
+#   2  no such container, or container has no health check configured
+set -euo pipefail
+
+container=""
+timeout=120
+interval=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)  timeout="$2";  shift 2 ;;
+    --interval) interval="$2"; shift 2 ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *) container="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$container" ]]; then
+  echo "Usage: wait-for-healthy.sh <container> [--timeout SECS] [--interval SECS]" >&2
+  exit 2
+fi
+
+if ! docker inspect "$container" >/dev/null 2>&1; then
+  echo "Error: no such container: $container" >&2
+  exit 2
+fi
+
+health="$(docker inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null || echo "")"
+if [[ -z "$health" ]]; then
+  echo "Error: container '$container' has no health check configured" >&2
+  exit 2
+fi
+
+elapsed=0
+while [[ "$health" != "healthy" && $elapsed -lt $timeout ]]; do
+  sleep "$interval"
+  elapsed=$((elapsed + interval))
+  health="$(docker inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null || echo "unknown")"
+done
+
+if [[ "$health" == "healthy" ]]; then
+  echo "$container is healthy (after ${elapsed}s)"
+  exit 0
+fi
+
+echo "Error: $container did not become healthy within ${timeout}s (last status: $health)" >&2
+exit 1

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -595,8 +595,8 @@ git diff develop..<feature_branch> --name-only | grep -E "(package\.json|package
 
 If any dependency file changed:
 - Frontend: `cd backend/docker && ./stop.sh && ./start.sh`
-- Backend only: `docker restart pam_api && sleep 15`
-Wait for containers to be healthy.
+- Backend only: `docker restart pam_api`
+Wait for containers to be healthy: `~/.claude/bin/wait-for-healthy.sh pam_api`
 
 ### Step 2: Container health check
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -114,7 +114,7 @@ The orchestrator (main session) only:
 Before spawning, collect:
 - `base_branch` — from `~/.claude/bin/git-find-base-branch`
 - `acceptance_criteria` — the AC list parsed in Phase 1 (or "none" if not found)
-- `modified_files` — `git diff --name-only $(git merge-base HEAD <base-branch>)..HEAD`
+- `modified_files` — `~/.claude/bin/git-diff-base.sh <base-branch>`
 - `has_backend_endpoints` — true if any modified file matches `**/api/**`, `**/routes/**`, `**/endpoints/**`
 - `has_schema_changes` — true if any modified file matches `**/schemas/**`, `**/models/**`, `**/migrations/**`
 
@@ -175,14 +175,14 @@ For UNVERIFIED items: write a test if testable, else flag for manual review.
 
 ### Step E: Self-review (max 2 fix iterations)
 Run the `/review` analysis on the branch diff:
-`git diff $(git merge-base HEAD <base-branch>)..HEAD`
+`~/.claude/bin/git-diff-base.sh --patch <base-branch>`
 
 If findings with severity > INFO:
 - Fix automatically, re-run Step A, re-run review
 - Max 2 iterations — remaining findings go into the PR body as "Known Issues"
 
 ### Step F: API smoke test (skip if has_backend_endpoints = false)
-1. Restart API container: `docker restart pam_api && sleep 8`
+1. Restart API container: `docker restart pam_api`, then wait for it to come back up: `~/.claude/bin/wait-for-healthy.sh pam_api`
 2. Seed E2E accounts if needed: `npm run db:seed:e2e`
 3. Login: `./scripts/api-login.sh premium` then read `/tmp/pam-token.txt`
 4. Call each new/modified endpoint, verify 2xx + correct JSON structure


### PR DESCRIPTION
Closes #11

## Summary

The `/implement` and `/implement-epic` skills embedded shell constructs that the Bash permission matcher can't allowlist: `$(git merge-base ...)` command substitution, and fixed `docker restart X && sleep N` chains. Both trigger avoidable permission prompts on every run.

- **`bin/git-diff-base.sh`** (extended): now accepts an optional positional base-branch argument and auto-resolves the base via `git-find-base-branch` when omitted, instead of hardcoding `main`. Existing `--base`/`--repo`/`--stat`/`--patch` flags kept for backward compatibility.
- **`bin/wait-for-healthy.sh`** (new): polls a container's Docker health status until healthy or timeout. Exit codes: `0` healthy, `1` timeout, `2` no such container / no health check configured.
- Updated `skills/implement/SKILL.md` and `skills/implement-epic/SKILL.md` (including the embedded verification sub-agent prompt) to use these wrappers instead of `$(...)` substitution and fixed sleeps.

## Test checklist

No automated test suite applies to this repo (bash scripts + markdown skills). Verified via direct execution in a sub-agent:
- [x] `shellcheck` clean on both scripts
- [x] `git-diff-base.sh` — no-args auto-detect, positional base arg, `--stat`/`--patch` modes, detached HEAD
- [x] `wait-for-healthy.sh` — nonexistent container (exit 2), no-health-check container (exit 2), real healthy container (exit 0)
- [x] `grep -n 'merge-base' skills/implement/SKILL.md skills/implement-epic/SKILL.md` — no matches
- [x] No `until ... sleep` polling loops remain in either target skill file
- [x] Both scripts have a usage comment header matching house style

## Scope note

Pre-existing `$(git merge-base ...)` usages in `skills/pre-merge/SKILL.md` and `skills/review/SKILL.md` were intentionally left untouched — out of scope for this issue, which targets only `/implement` and `/implement-epic`.
