### PR TITLE
fix(bin): git-find-base-branch returns current when it's already develop/master/main

### DIFF
--- a/bin/git-find-base-branch
+++ b/bin/git-find-base-branch
@@ -2,6 +2,10 @@
 # Find the base branch a feature branch should target / was branched from.
 #
 # Strategy (in order):
+#   0. If current itself is a known integration branch (develop/master/main),
+#      that IS the base — return it directly. Handles running the skill from
+#      develop itself, where master (being an ancestor of develop) would
+#      otherwise be picked by step 1.
 #   1. Prefer a known integration branch (develop > master > main) when it is an
 #      ancestor of the current branch. A feature branch cut from develop will
 #      have develop as an ancestor, so this returns the real integration target
@@ -14,8 +18,19 @@
 
 current=$(git branch --show-current)
 
+# 0. If we're already sitting on an integration branch, that IS the base —
+#    e.g. running from `develop` itself must return `develop`, not fall
+#    through to `master` just because master is an ancestor of develop.
+for branch in develop master main; do
+    if [ "$branch" = "$current" ]; then
+        echo "$branch"
+        exit 0
+    fi
+done
+
 # 1. Prefer a known integration branch that is an ancestor of current.
-#    Skip current itself so `develop` returns `master`, not `develop`.
+#    Skip current itself so a feature branch cut from develop returns
+#    `develop`, not itself.
 for branch in develop master main; do
     [ "$branch" = "$current" ] && continue
     git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null || continue

--- a/bin/test-git-find-base-branch.sh
+++ b/bin/test-git-find-base-branch.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Regression tests for git-find-base-branch.
+#
+# Covers the three scenarios from issue #17:
+#   1. On develop itself (master is an ancestor)      -> expect develop
+#   2. On a feature branch cut from develop            -> expect develop
+#   3. Repo with only master (no develop)               -> expect master
+#
+# Each scenario builds a throwaway repo under a temp dir so it never touches
+# the real toolkit repo's branches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/git-find-base-branch"
+
+pass=0
+fail=0
+
+run_case() {
+    local name="$1"
+    local expected="$2"
+    local repo="$3"
+
+    actual=$(cd "$repo" && "$TARGET")
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $name (got '$actual')"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $name (expected '$expected', got '$actual')"
+        fail=$((fail + 1))
+    fi
+}
+
+make_repo() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init -q
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    echo "$dir"
+}
+
+# Scenario 1: on develop, master is an ancestor of develop.
+repo1=$(make_repo)
+git -C "$repo1" checkout -q -b master
+git -C "$repo1" commit -q --allow-empty -m "master root"
+git -C "$repo1" checkout -q -b develop
+git -C "$repo1" commit -q --allow-empty -m "develop ahead"
+run_case "on develop (master ancestor)" "develop" "$repo1"
+rm -rf "$repo1"
+
+# Scenario 2: on a feature branch cut from develop.
+repo2=$(make_repo)
+git -C "$repo2" checkout -q -b master
+git -C "$repo2" commit -q --allow-empty -m "master root"
+git -C "$repo2" checkout -q -b develop
+git -C "$repo2" commit -q --allow-empty -m "develop ahead"
+git -C "$repo2" checkout -q -b issue-1-feature
+git -C "$repo2" commit -q --allow-empty -m "feature work"
+run_case "on feature branch cut from develop" "develop" "$repo2"
+rm -rf "$repo2"
+
+# Scenario 3: repo with only master (no develop).
+repo3=$(make_repo)
+git -C "$repo3" checkout -q -b master
+git -C "$repo3" commit -q --allow-empty -m "master root"
+git -C "$repo3" checkout -q -b issue-2-feature
+git -C "$repo3" commit -q --allow-empty -m "feature work"
+run_case "repo without develop" "master" "$repo3"
+rm -rf "$repo3"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #17

## Summary

`bin/git-find-base-branch` returned `master` instead of `develop` when invoked while already sitting on `develop` (because `master` is an ancestor of `develop`, and the old step-1 loop unconditionally skipped `current`, causing it to fall through to `master`).

Fix: added a "step 0" check — if `current` is itself `develop`/`master`/`main`, return it immediately, before the ancestor-search loop that skips `current` for the feature-branch case. Steps 1–3 (feature-branch and no-develop fallbacks) are untouched.

## Changes

- `bin/git-find-base-branch`: added step 0 early-return for when current branch is itself an integration branch
- `bin/test-git-find-base-branch.sh`: new regression test covering the three scenarios from the issue

## Test checklist

- [x] 3/3 regression tests pass (`bash bin/test-git-find-base-branch.sh`)
- [x] shellcheck clean on both changed files (`~/.claude/bin/shell-check.sh <repo> bin`)
- [x] Confirmed test is a genuine regression test (reverted fix → scenario 1 fails as before; restored → all pass)

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `git-find-base-branch` from `develop` (master ancestor) returns `develop` | ✅ Verified |
| 2 | Feature branch cut from `develop` returns `develop` | ✅ Verified |
| 3 | Repos without `develop` (only master/main) still work | ✅ Verified |
| 4 | Regression test covering all three cases exists | ✅ Verified |
