### PR TITLE
git-push-pr-merge.sh: gate merges on green CI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
 | `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents) |
-| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, merge, return to base (for `/implement-epic`) |
+| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on required CI checks, merge, return to base (for `/implement-epic`) |
 
 ### Project audits
 

--- a/bin/git-push-pr-merge.sh
+++ b/bin/git-push-pr-merge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# git-push-pr-merge.sh — Push branch, create PR, merge, return to base branch.
+# git-push-pr-merge.sh — Push branch, create PR, gate on CI, merge, return to base branch.
 #
 # Wraps the full post-commit workflow for sub-agents in implement-epic.
 # Avoids multiline/heredoc issues by accepting PR body from a file.
@@ -10,14 +10,25 @@
 # What it does:
 #   1. Push current branch to origin (with -u)
 #   2. Create PR against base branch
-#   3. Merge PR (--merge --delete-branch)
-#   4. Checkout base branch and pull
+#   3. If merging: wait for required CI checks to go green (see CI gate below)
+#   4. Merge PR (--merge --delete-branch)
+#   5. Checkout base branch and pull
+#
+# CI gate (skipped entirely when --no-merge is set):
+#   After PR creation, required checks (`gh pr checks --required`) are polled
+#   until they all pass, one fails, or --ci-timeout elapses. A repo with no
+#   checks configured skips the gate and merges as before. On failure or
+#   timeout the PR is left open, a `CI_GATE: FAIL|TIMEOUT` line is printed,
+#   and the script exits non-zero so callers can react.
 #
 # Options:
-#   --base <branch>       Target branch for the PR (required)
-#   --title <title>       PR title (required)
-#   --body-file <path>    File containing PR body (required)
-#   --no-merge            Create PR but don't merge (for manual review)
+#   --base <branch>            Target branch for the PR (required)
+#   --title <title>            PR title (required)
+#   --body-file <path>         File containing PR body (required)
+#   --no-merge                 Create PR but don't merge (for manual review) — CI gate is skipped
+#   --no-ci-wait                Merge immediately without waiting for CI checks
+#   --ci-timeout <secs>         Max time to wait for checks (default: 900)
+#   --ci-poll-interval <secs>   Polling interval while waiting (default: 15)
 
 set -euo pipefail
 
@@ -25,6 +36,9 @@ BASE=""
 TITLE=""
 BODY_FILE=""
 DO_MERGE=1
+CI_WAIT=1
+CI_TIMEOUT=900
+CI_POLL_INTERVAL=15
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -43,6 +57,18 @@ while [[ $# -gt 0 ]]; do
         --no-merge)
             DO_MERGE=0
             shift
+            ;;
+        --no-ci-wait)
+            CI_WAIT=0
+            shift
+            ;;
+        --ci-timeout)
+            CI_TIMEOUT="$2"
+            shift 2
+            ;;
+        --ci-poll-interval)
+            CI_POLL_INTERVAL="$2"
+            shift 2
             ;;
         *)
             echo "Error: Unknown option: $1" >&2
@@ -84,7 +110,75 @@ PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
 
 echo "Created PR #$PR_NUMBER: $PR_URL"
 
+# wait_for_ci_gate: polls required checks on $PR_NUMBER until they all pass,
+# one fails, or CI_TIMEOUT elapses. Prints a CI_GATE status line and returns
+# non-zero on FAIL/TIMEOUT/unverifiable so the caller can bail before merging.
+wait_for_ci_gate() {
+    local elapsed=0
+    local retried_transient=0
+
+    while true; do
+        local checks_json
+        local checks_exit=0
+        checks_json=$(gh pr checks "$PR_NUMBER" --required --json name,bucket 2>/tmp/ci-gate-stderr.$$) || checks_exit=$?
+        local checks_stderr
+        checks_stderr=$(cat /tmp/ci-gate-stderr.$$ 2>/dev/null || true)
+        rm -f /tmp/ci-gate-stderr.$$
+
+        if [[ "$checks_exit" -ne 0 ]]; then
+            if echo "$checks_stderr" | grep -qi "no checks reported"; then
+                echo "CI_GATE: SKIP — no checks configured"
+                return 0
+            fi
+            # Transient gh error (rate limit, network blip): retry once, then fail closed.
+            if [[ "$retried_transient" -eq 0 ]]; then
+                retried_transient=1
+                echo "CI gate: transient error from gh, retrying once: $checks_stderr" >&2
+                sleep 1
+                continue
+            fi
+            echo "CI_GATE: FAIL — unable to verify checks: $checks_stderr"
+            return 1
+        fi
+
+        local fail_names
+        fail_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | map(.name) | join(",")')
+        if [[ -n "$fail_names" ]]; then
+            echo "CI_GATE: FAIL — $fail_names"
+            return 1
+        fi
+
+        local pending_names
+        pending_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")')
+        if [[ -z "$pending_names" ]]; then
+            echo "CI_GATE: PASS"
+            return 0
+        fi
+
+        if [[ "$elapsed" -ge "$CI_TIMEOUT" ]]; then
+            echo "CI_GATE: TIMEOUT — still pending: $pending_names"
+            return 1
+        fi
+
+        sleep "$CI_POLL_INTERVAL"
+        elapsed=$((elapsed + CI_POLL_INTERVAL))
+    done
+}
+
 if [[ "$DO_MERGE" -eq 1 ]]; then
+    if [[ "$CI_WAIT" -eq 1 ]]; then
+        echo "=== Waiting for CI checks on PR #$PR_NUMBER ==="
+        if ! wait_for_ci_gate; then
+            echo "=== CI gate failed — leaving PR #$PR_NUMBER open ===" >&2
+            echo "PR_NUMBER: $PR_NUMBER"
+            echo "PR_URL: $PR_URL"
+            echo "STATUS: CI_GATE_BLOCKED"
+            exit 1
+        fi
+    else
+        echo "CI_GATE: SKIP — --no-ci-wait"
+    fi
+
     echo "=== Merging PR #$PR_NUMBER ==="
     gh pr merge "$PR_NUMBER" --merge --delete-branch
 

--- a/bin/git-push-pr-merge.sh
+++ b/bin/git-push-pr-merge.sh
@@ -116,14 +116,16 @@ echo "Created PR #$PR_NUMBER: $PR_URL"
 wait_for_ci_gate() {
     local elapsed=0
     local retried_transient=0
+    local stderr_file
+    stderr_file=$(mktemp)
+    trap 'rm -f "$stderr_file"' RETURN
 
     while true; do
         local checks_json
         local checks_exit=0
-        checks_json=$(gh pr checks "$PR_NUMBER" --required --json name,bucket 2>/tmp/ci-gate-stderr.$$) || checks_exit=$?
+        checks_json=$(gh pr checks "$PR_NUMBER" --required --json name,bucket 2>"$stderr_file") || checks_exit=$?
         local checks_stderr
-        checks_stderr=$(cat /tmp/ci-gate-stderr.$$ 2>/dev/null || true)
-        rm -f /tmp/ci-gate-stderr.$$
+        checks_stderr=$(cat "$stderr_file" 2>/dev/null || true)
 
         if [[ "$checks_exit" -ne 0 ]]; then
             if echo "$checks_stderr" | grep -qi "no checks reported"; then
@@ -141,15 +143,22 @@ wait_for_ci_gate() {
             return 1
         fi
 
+        local jq_exit=0
         local fail_names
-        fail_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | map(.name) | join(",")')
+        fail_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | map(.name) | join(",")') || jq_exit=$?
+        local pending_names
+        pending_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")') || jq_exit=$?
+
+        if [[ "$jq_exit" -ne 0 ]]; then
+            echo "CI_GATE: FAIL — unable to parse checks output from gh"
+            return 1
+        fi
+
         if [[ -n "$fail_names" ]]; then
             echo "CI_GATE: FAIL — $fail_names"
             return 1
         fi
 
-        local pending_names
-        pending_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")')
         if [[ -z "$pending_names" ]]; then
             echo "CI_GATE: PASS"
             return 0

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -93,6 +93,10 @@ case "$1 $2" in
                 fi
                 exit 0
                 ;;
+            malformed-json)
+                echo 'not valid json {{{'
+                exit 0
+                ;;
         esac
         ;;
     "pr merge")
@@ -257,6 +261,16 @@ run_case "transient error then pass" "$repo6" "ratelimit-then-pass" --ci-timeout
 assert_contains "transient error: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo6/last-output.txt")"
 assert_file_present "transient error: merge happened" "$repo6/merged"
 rm -rf "$repo6"
+
+# --- Scenario 6b: malformed JSON from gh -> fail closed, no merge, no crash ---
+repo6b=$(make_repo)
+make_fake_gh "$repo6b"
+echo "Test PR body" > "$repo6b/body.md"
+run_case "malformed json" "$repo6b" "malformed-json"
+assert_contains "malformed json: CI_GATE line" "CI_GATE: FAIL" "$(cat "$repo6b/last-output.txt")"
+assert_exit "malformed json: exit code" "1" "$(cat "$repo6b/last-exit.txt")"
+assert_file_absent "malformed json: no merge" "$repo6b/merged"
+rm -rf "$repo6b"
 
 # --- Scenario 7: --no-ci-wait skips the gate even with failing checks ---
 repo7=$(make_repo)

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Regression tests for git-push-pr-merge.sh's CI gate (issue #13).
+#
+# Covers:
+#   1. No checks configured           -> CI_GATE: SKIP, merges
+#   2. Required checks pass           -> CI_GATE: PASS, merges
+#   3. A required check fails         -> CI_GATE: FAIL, no merge, exit non-zero
+#   4. Checks stuck pending (timeout) -> CI_GATE: TIMEOUT, no merge, exit non-zero
+#   5. --no-ci-wait                   -> merges without checking, regardless of check state
+#   6. --no-merge                     -> CI gate skipped entirely, unaffected
+#
+# Each scenario builds a throwaway repo and a fake `gh`/`git push` stub so it
+# never touches a real GitHub repo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/git-push-pr-merge.sh"
+
+pass=0
+fail=0
+
+make_repo() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init -q
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    git -C "$dir" checkout -q -b main
+    git -C "$dir" commit -q --allow-empty -m "root"
+    git -C "$dir" checkout -q -b issue-1-feature
+    git -C "$dir" commit -q --allow-empty -m "feature work"
+    echo "$dir"
+}
+
+# Builds a fake `gh` binary in $1/bin that:
+#   - `gh pr create` prints a fake PR URL
+#   - `gh pr checks` behavior driven by $1/checks-state (see scenarios below)
+#   - `gh pr merge` records that merge happened into $1/merged
+make_fake_gh() {
+    local workdir="$1"
+    local bindir="$workdir/bin"
+    mkdir -p "$bindir"
+
+    cat > "$bindir/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+WORKDIR="$FAKE_GH_WORKDIR"
+
+case "$1 $2" in
+    "pr create")
+        echo "https://github.com/example/repo/pull/42"
+        exit 0
+        ;;
+    "pr checks")
+        # checks-state file contains one of: none, pass, fail, pending-then-pass, pending-forever, ratelimit-then-pass
+        state=$(cat "$WORKDIR/checks-state" 2>/dev/null || echo "none")
+        count_file="$WORKDIR/checks-call-count"
+        count=$(cat "$count_file" 2>/dev/null || echo "0")
+        count=$((count + 1))
+        echo "$count" > "$count_file"
+
+        case "$state" in
+            none)
+                echo "no checks reported on the '42' pull request" >&2
+                exit 1
+                ;;
+            pass)
+                echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
+                exit 0
+                ;;
+            fail)
+                echo '[{"name":"build","state":"FAILURE","bucket":"fail"}]'
+                exit 0
+                ;;
+            pending-then-pass)
+                if [ "$count" -lt 2 ]; then
+                    echo '[{"name":"build","state":"PENDING","bucket":"pending"}]'
+                else
+                    echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
+                fi
+                exit 0
+                ;;
+            pending-forever)
+                echo '[{"name":"build","state":"PENDING","bucket":"pending"}]'
+                exit 0
+                ;;
+            ratelimit-then-pass)
+                if [ "$count" -lt 2 ]; then
+                    echo "API rate limit exceeded" >&2
+                    exit 1
+                else
+                    echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
+                fi
+                exit 0
+                ;;
+        esac
+        ;;
+    "pr merge")
+        echo "merged" > "$WORKDIR/merged"
+        exit 0
+        ;;
+    *)
+        echo "fake gh: unhandled args: $*" >&2
+        exit 1
+        ;;
+esac
+FAKE_GH
+    chmod +x "$bindir/gh"
+    # Bake the workdir path into the script itself (avoids env export plumbing through git push -u).
+    sed -i "s#\$FAKE_GH_WORKDIR#$workdir#" "$bindir/gh"
+
+    # Fake `git` that only intercepts `push`/`pull` (network ops); everything
+    # else delegates to the real git so branch/commit machinery still works.
+    cat > "$bindir/git" <<FAKE_GIT
+#!/usr/bin/env bash
+if [ "\$1" = "push" ] || [ "\$1" = "pull" ]; then
+    exit 0
+fi
+exec $(command -v git) "\$@"
+FAKE_GIT
+    chmod +x "$bindir/git"
+}
+
+run_case() {
+    local name="$1"
+    local repo="$2"
+    local checks_state="$3"
+    shift 3
+    local extra_args=("$@")
+
+    echo "$checks_state" > "$repo/checks-state"
+    rm -f "$repo/merged" "$repo/checks-call-count"
+
+    set +e
+    output=$(cd "$repo" && PATH="$repo/bin:$PATH" "$TARGET" --base main --title "Test PR" --body-file "$repo/body.md" "${extra_args[@]}" 2>&1)
+    actual_exit=$?
+    set -e
+
+    echo "$output" > "$repo/last-output.txt"
+    echo "$actual_exit" > "$repo/last-exit.txt"
+    echo "$name"
+}
+
+assert_contains() {
+    local case_name="$1"
+    local needle="$2"
+    local haystack="$3"
+
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "PASS: $case_name (found '$needle')"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $case_name (expected to find '$needle')"
+        echo "--- output ---"
+        echo "$haystack"
+        echo "--------------"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_exit() {
+    local case_name="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $case_name (exit $actual)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $case_name (expected exit $expected, got $actual)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_file_absent() {
+    local case_name="$1"
+    local path="$2"
+
+    if [ ! -f "$path" ]; then
+        echo "PASS: $case_name (no merge happened)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $case_name (merge happened but should not have)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_file_present() {
+    local case_name="$1"
+    local path="$2"
+
+    if [ -f "$path" ]; then
+        echo "PASS: $case_name (merge happened)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $case_name (merge did not happen but should have)"
+        fail=$((fail + 1))
+    fi
+}
+
+# --- Scenario 1: no checks configured -> skip gate, merge proceeds ---
+repo1=$(make_repo)
+make_fake_gh "$repo1"
+echo "Test PR body" > "$repo1/body.md"
+run_case "no checks" "$repo1" "none"
+assert_contains "no checks: CI_GATE line" "CI_GATE: SKIP" "$(cat "$repo1/last-output.txt")"
+assert_exit "no checks: exit code" "0" "$(cat "$repo1/last-exit.txt")"
+assert_file_present "no checks: merge happened" "$repo1/merged"
+rm -rf "$repo1"
+
+# --- Scenario 2: required checks pass -> merge proceeds ---
+repo2=$(make_repo)
+make_fake_gh "$repo2"
+echo "Test PR body" > "$repo2/body.md"
+run_case "checks pass" "$repo2" "pass"
+assert_contains "checks pass: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo2/last-output.txt")"
+assert_exit "checks pass: exit code" "0" "$(cat "$repo2/last-exit.txt")"
+assert_file_present "checks pass: merge happened" "$repo2/merged"
+rm -rf "$repo2"
+
+# --- Scenario 3: a required check fails -> no merge, non-zero exit ---
+repo3=$(make_repo)
+make_fake_gh "$repo3"
+echo "Test PR body" > "$repo3/body.md"
+run_case "checks fail" "$repo3" "fail"
+assert_contains "checks fail: CI_GATE line" "CI_GATE: FAIL" "$(cat "$repo3/last-output.txt")"
+assert_contains "checks fail: names failing check" "build" "$(cat "$repo3/last-output.txt")"
+assert_exit "checks fail: exit code" "1" "$(cat "$repo3/last-exit.txt")"
+assert_file_absent "checks fail: no merge" "$repo3/merged"
+rm -rf "$repo3"
+
+# --- Scenario 4: checks pending forever -> timeout, no merge ---
+repo4=$(make_repo)
+make_fake_gh "$repo4"
+echo "Test PR body" > "$repo4/body.md"
+run_case "checks timeout" "$repo4" "pending-forever" --ci-timeout 2 --ci-poll-interval 1
+assert_contains "timeout: CI_GATE line" "CI_GATE: TIMEOUT" "$(cat "$repo4/last-output.txt")"
+assert_exit "timeout: exit code" "1" "$(cat "$repo4/last-exit.txt")"
+assert_file_absent "timeout: no merge" "$repo4/merged"
+rm -rf "$repo4"
+
+# --- Scenario 5: checks pending then pass within timeout -> merge proceeds ---
+repo5=$(make_repo)
+make_fake_gh "$repo5"
+echo "Test PR body" > "$repo5/body.md"
+run_case "checks pending then pass" "$repo5" "pending-then-pass" --ci-timeout 30 --ci-poll-interval 1
+assert_contains "pending-then-pass: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo5/last-output.txt")"
+assert_exit "pending-then-pass: exit code" "0" "$(cat "$repo5/last-exit.txt")"
+assert_file_present "pending-then-pass: merge happened" "$repo5/merged"
+rm -rf "$repo5"
+
+# --- Scenario 6: transient gh error retried once, then succeeds ---
+repo6=$(make_repo)
+make_fake_gh "$repo6"
+echo "Test PR body" > "$repo6/body.md"
+run_case "transient error then pass" "$repo6" "ratelimit-then-pass" --ci-timeout 30 --ci-poll-interval 1
+assert_contains "transient error: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo6/last-output.txt")"
+assert_file_present "transient error: merge happened" "$repo6/merged"
+rm -rf "$repo6"
+
+# --- Scenario 7: --no-ci-wait skips the gate even with failing checks ---
+repo7=$(make_repo)
+make_fake_gh "$repo7"
+echo "Test PR body" > "$repo7/body.md"
+run_case "no-ci-wait with failing checks" "$repo7" "fail" --no-ci-wait
+assert_contains "no-ci-wait: CI_GATE line" "CI_GATE: SKIP" "$(cat "$repo7/last-output.txt")"
+assert_exit "no-ci-wait: exit code" "0" "$(cat "$repo7/last-exit.txt")"
+assert_file_present "no-ci-wait: merge happened" "$repo7/merged"
+rm -rf "$repo7"
+
+# --- Scenario 8: --no-merge is unaffected (gate skipped, no merge, no CI_GATE noise) ---
+repo8=$(make_repo)
+make_fake_gh "$repo8"
+echo "Test PR body" > "$repo8/body.md"
+run_case "no-merge path" "$repo8" "fail" --no-merge
+assert_exit "no-merge: exit code" "0" "$(cat "$repo8/last-exit.txt")"
+assert_file_absent "no-merge: no merge" "$repo8/merged"
+rm -rf "$repo8"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -212,7 +212,12 @@ Read only the files relevant to your issue. Do NOT skip this step.
    - Commit: `~/.claude/bin/git-commit.sh "concise descriptive message"`
    - Write PR body to /tmp/pr-body.md using the Write tool, then push + PR + merge in one command:
      `~/.claude/bin/git-push-pr-merge.sh --base <feature_branch> --title "<title>" --body-file /tmp/pr-body.md`
-   - This script pushes, creates the PR, merges it, and returns to the feature branch automatically
+   - This script pushes, creates the PR, waits for required CI checks, merges it, and returns to the feature branch automatically
+   - **If the script exits non-zero with `STATUS: CI_GATE_BLOCKED`:** the PR was left open — checks failed or timed out.
+     - Read the `CI_GATE: FAIL — <check names>` or `CI_GATE: TIMEOUT — <check names>` line to identify the failing/stuck checks
+     - Investigate the failure (`gh pr checks <PR_NUMBER>`, CI logs), fix at root cause, commit, push to the same branch
+     - Re-run `~/.claude/bin/git-push-pr-merge.sh` with the same arguments to re-trigger the gate
+     - Up to 3 fix-and-retry attempts; if still blocked, leave the PR open and report the blocker instead of forcing a merge
 
 ## Auth Impact Check (only include if auth_impact is true)
 This issue changes user status/role/auth fields. BEFORE writing tests:

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -236,6 +236,7 @@ Before proceeding to PR creation:
    - If SENTRY_ISSUES were found in Phase 1, add a `## Sentry` section: `Resolves: PAM-BACKEND-G, PAM-BACKEND-H`
 3. Push + create PR in one command:
    `~/.claude/bin/git-push-pr-merge.sh --base <base-branch> --title "<concise description>" --body-file /tmp/pr-body.md --no-merge`
+   `--no-merge` means the CI gate is skipped — the PR is left open for human review regardless of check status
 4. Return PR URL for review
 
 ## Phase 5: Epic Tracking Update (automatic, if applicable)


### PR DESCRIPTION
Closes #13

## Summary

`git-push-pr-merge.sh` previously pushed, created the PR, and merged it in one motion with no CI gate — a sub-PR could merge with failing checks, discovered only later once the integration branch was already red.

This adds a CI gate between PR creation and merge:
- Polls `gh pr checks --required` after PR creation (before merging)
- Merges only when all required checks pass
- On failure: leaves the PR open, prints `CI_GATE: FAIL — <failing check names>`, exits non-zero
- On timeout (`--ci-timeout`, default 900s): leaves the PR open, prints `CI_GATE: TIMEOUT — <pending check names>`, exits non-zero
- No checks configured: skips the gate, merges as before, prints `CI_GATE: SKIP — no checks configured`
- `--no-ci-wait`: opt out entirely, restores pre-issue behavior
- `--no-merge`: unaffected — the gate never runs since no merge happens
- Transient `gh` errors (rate limit, network blip) are retried once, then fail closed
- Malformed/unparseable JSON from `gh` fails closed with `CI_GATE: FAIL` rather than crashing the script uncaught

`skills/implement-epic/SKILL.md` is updated so its per-sub-issue sub-agent recognizes `STATUS: CI_GATE_BLOCKED`, reads the `CI_GATE` line to find the failing/stuck checks, and fixes-and-retries (up to 3 attempts) instead of assuming the merge succeeded. `skills/implement/SKILL.md` notes that its `--no-merge` usage skips the gate entirely.

## Test plan

- [x] `bin/test-git-push-pr-merge.sh` — new regression suite using a fake `gh`/`git` stub, 26/26 assertions passing:
  - no checks configured → skip, merges
  - required checks pass → merges
  - a required check fails → no merge, `CI_GATE: FAIL`, exit 1
  - checks stuck pending past timeout → no merge, `CI_GATE: TIMEOUT`, exit 1
  - checks pending then pass within timeout → merges
  - transient `gh` error retried once then succeeds → merges
  - malformed JSON from `gh` → fails closed, `CI_GATE: FAIL`, no crash
  - `--no-ci-wait` → merges despite failing checks (opt-out restores old behavior)
  - `--no-merge` → unaffected, no merge, no CI gate noise
- [x] `bin/test-git-find-base-branch.sh` (sibling test) — 3/3 passing, unaffected by this change
- [x] `shellcheck` clean on both modified/new bash files
