### PR TITLE
retro: measure permission friction from session transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 
 All scripts are already allowed in the global settings (`~/.claude/settings.json`) installed by the toolkit.
 
+### Diagnostics
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `permission-friction.py` | `permission-friction.py [project-dir] [--days N] [--json]` | Scan session transcripts for permission friction: estimated prompted calls, explicit denials, and top prompt-causing patterns. Used by `/retro`'s Permission Friction phase |
+
 ## Repository Structure
 
 ```
@@ -205,7 +211,9 @@ claude-code-toolkit/
 │   ├── hook-auto-approve-bash.py  ← real implementation: shlex-tokenized compound-command approval
 │   ├── test-hook-auto-approve-bash.py ← standalone tests for the above
 │   ├── hook-block-destructive.sh  ← PreToolUse hook: block destructive commands
-│   └── hook-post-edit-lint.sh     ← PostToolUse hook: ruff lint after Write/Edit
+│   ├── hook-post-edit-lint.sh     ← PostToolUse hook: ruff lint after Write/Edit
+│   ├── permission-friction.py     ← scan transcripts for permission friction (used by /retro)
+│   └── test-permission-friction.py ← standalone tests for the above
 ├── skills/                    ← skill definitions (procedures)
 │   ├── refine/
 │   ├── implement/

--- a/bin/permission-friction.py
+++ b/bin/permission-friction.py
@@ -167,3 +167,118 @@ def classify_command(command, allow_rules, deny_rules):
         return False, None
 
     return True, REASON_NO_RULE
+
+
+def _encode_project_dir(project_dir):
+    """Mirror Claude Code's transcript-directory naming: absolute path with
+    every "/" replaced by "-"."""
+    return str(Path(project_dir).resolve()).replace(os.sep, "-")
+
+
+def _transcript_dir_for(project_dir):
+    return PROJECTS_TRANSCRIPTS_DIR / _encode_project_dir(project_dir)
+
+
+def _parse_timestamp(value):
+    """Parse a transcript ISO-8601 timestamp ("...Z") to a comparable
+    value, or None if missing/malformed."""
+    if not value:
+        return None
+    try:
+        from datetime import datetime
+
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _cutoff(days):
+    from datetime import datetime, timedelta, timezone
+
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def iter_transcript_events(project_dir, days=30):
+    """Yield (session_id, timestamp, message_content_list) for every
+    transcript line within the last `days` days that carries a message
+    with list-shaped content (tool_use/tool_result entries live there).
+
+    Silently yields nothing if the transcript directory doesn't exist or
+    contains no matching files — scanning transcripts is best-effort, not
+    a hard requirement.
+    """
+    transcript_dir = _transcript_dir_for(project_dir)
+    if not transcript_dir.is_dir():
+        return
+
+    cutoff = _cutoff(days)
+
+    for jsonl_path in sorted(transcript_dir.glob("*.jsonl")):
+        session_id = jsonl_path.stem
+        try:
+            lines = jsonl_path.read_text().splitlines()
+        except OSError:
+            continue
+
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            ts = _parse_timestamp(obj.get("timestamp"))
+            if ts is not None and ts < cutoff:
+                continue
+
+            message = obj.get("message")
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+
+            yield session_id, ts, content
+
+
+def iter_denied_tool_use_ids(project_dir, days=30):
+    """Yield (session_id, tool_use_id) for every tool_result whose content
+    carries the explicit user-rejection marker. This is the only reliable
+    transcript signal for a denial — Claude Code does not log a distinct
+    event for "prompt shown and approved.\""""
+    for session_id, _ts, content in iter_transcript_events(project_dir, days):
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            block_content = block.get("content")
+            text = block_content if isinstance(block_content, str) else json.dumps(block_content)
+            if REJECTION_MARKER in text:
+                tool_use_id = block.get("tool_use_id")
+                if tool_use_id:
+                    yield session_id, tool_use_id
+
+
+def collect_bash_tool_uses(project_dir, days=30):
+    """Return a list of dicts {session_id, tool_use_id, command} for every
+    Bash tool_use in the scanned window, keyed so denials can be joined
+    back to the command that was denied."""
+    results = []
+    for session_id, _ts, content in iter_transcript_events(project_dir, days):
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "Bash"
+            ):
+                command = block.get("input", {}).get("command")
+                tool_use_id = block.get("id")
+                if command:
+                    results.append(
+                        {
+                            "session_id": session_id,
+                            "tool_use_id": tool_use_id,
+                            "command": command,
+                        }
+                    )
+    return results

--- a/bin/permission-friction.py
+++ b/bin/permission-friction.py
@@ -14,10 +14,12 @@ hardcoded allowlist, so it stays correct as the user's permissions evolve.
 """
 
 import argparse
+import fnmatch
 import importlib.util
 import json
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 _HOOK_PATH = Path(__file__).parent / "hook-auto-approve-bash.py"
@@ -27,8 +29,6 @@ _spec.loader.exec_module(_hook)
 
 CLAUDE_HOME = Path(os.path.expanduser("~/.claude"))
 PROJECTS_TRANSCRIPTS_DIR = CLAUDE_HOME / "projects"
-
-SETTINGS_FILENAMES = ("settings.json", "settings.local.json")
 
 REJECTION_MARKER = "The user doesn't want to proceed with this tool use"
 
@@ -103,8 +103,6 @@ def matches_bash_rule(command, rule):
 
     if pattern.endswith(":*"):
         pattern = pattern[:-2] + " *"
-
-    import fnmatch
 
     return fnmatch.fnmatchcase(command, pattern)
 
@@ -185,16 +183,12 @@ def _parse_timestamp(value):
     if not value:
         return None
     try:
-        from datetime import datetime
-
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
 
 
 def _cutoff(days):
-    from datetime import datetime, timedelta, timezone
-
     return datetime.now(timezone.utc) - timedelta(days=days)
 
 

--- a/bin/permission-friction.py
+++ b/bin/permission-friction.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Scan a project's Claude Code session transcripts for permission friction:
+how often Bash commands would have triggered a permission prompt, which
+patterns caused it, and how often calls were explicitly denied.
+
+Run directly: python3 bin/permission-friction.py [project-dir] [--days N] [--json]
+Or via venv: ~/.claude/bin/venv-run.sh python bin/permission-friction.py
+
+Reads transcripts only (no network) from
+~/.claude/projects/<encoded-project-dir>/*.jsonl, and derives allow/deny
+rules by parsing the merged settings.json files at runtime — never a
+hardcoded allowlist, so it stays correct as the user's permissions evolve.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+_HOOK_PATH = Path(__file__).parent / "hook-auto-approve-bash.py"
+_spec = importlib.util.spec_from_file_location("hook_auto_approve_bash", _HOOK_PATH)
+_hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_hook)
+
+CLAUDE_HOME = Path(os.path.expanduser("~/.claude"))
+PROJECTS_TRANSCRIPTS_DIR = CLAUDE_HOME / "projects"
+
+SETTINGS_FILENAMES = ("settings.json", "settings.local.json")
+
+REJECTION_MARKER = "The user doesn't want to proceed with this tool use"
+
+
+def _read_json_file(path):
+    """Return the parsed JSON object at `path`, or None if missing/invalid.
+
+    Missing or malformed settings files are not a hard error — the merge
+    just proceeds without that scope's rules.
+    """
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def load_allow_rules(project_dir):
+    """Merge `permissions.allow`/`permissions.deny` across every settings
+    scope that actually exists: user global, project shared, project local.
+
+    Returns (allow_patterns, deny_patterns) — flat lists of raw rule
+    strings (e.g. "Bash(git *)"), unioned across scopes. Precedence between
+    scopes does not matter here: we only need "is this command covered by
+    ANY allow rule," and deny rules always win regardless of origin.
+    """
+    candidate_files = [
+        CLAUDE_HOME / "settings.json",
+        Path(project_dir) / ".claude" / "settings.json",
+        Path(project_dir) / ".claude" / "settings.local.json",
+    ]
+
+    allow = []
+    deny = []
+    for path in candidate_files:
+        data = _read_json_file(path)
+        if not data:
+            continue
+        permissions = data.get("permissions", {})
+        allow.extend(permissions.get("allow", []))
+        deny.extend(permissions.get("deny", []))
+
+    return allow, deny
+
+
+def _bash_pattern_body(rule):
+    """Return the inner pattern of a Bash(...) rule, or None if `rule` is
+    not a Bash rule at all (e.g. "Write", "Read(~/.claude/**)")."""
+    if rule == "Bash":
+        return "*"
+    if rule.startswith("Bash(") and rule.endswith(")"):
+        return rule[len("Bash("):-1]
+    return None
+
+
+def matches_bash_rule(command, rule):
+    """True if `command` (a full command string) is covered by a single
+    Bash permission `rule`.
+
+    Grammar (see docs.claude.com/en/permissions):
+      Bash / Bash(*)      -> matches everything
+      Bash(cmd *)         -> first token "cmd", "*" matches rest incl. none
+      Bash(cmd:*)         -> equivalent to "Bash(cmd *)" (colon shorthand)
+      Bash(cmd*)          -> literal prefix match, no word boundary
+      Bash(exact string)  -> exact full-command match, no wildcard
+    Wildcards may also appear mid-pattern (e.g. "Bash(git * main)"); these
+    are handled generically via fnmatch after the colon-shorthand rewrite.
+    """
+    pattern = _bash_pattern_body(rule)
+    if pattern is None:
+        return False
+
+    if pattern.endswith(":*"):
+        pattern = pattern[:-2] + " *"
+
+    import fnmatch
+
+    return fnmatch.fnmatchcase(command, pattern)
+
+
+def command_matches_any_rule(command, rules):
+    return any(matches_bash_rule(command, rule) for rule in rules)

--- a/bin/permission-friction.py
+++ b/bin/permission-friction.py
@@ -282,3 +282,145 @@ def collect_bash_tool_uses(project_dir, days=30):
                         }
                     )
     return results
+
+
+def _pattern_key(command, reason):
+    """Normalize a command into a grouping key for the report: the first
+    whitespace token (the sub-command binary/verb) plus the friction
+    reason, e.g. "curl (no allow rule covers this command)". Grouping by
+    first-token mirrors how permission rules themselves match, so the key
+    directly identifies which allowlist entry would fix the pattern."""
+    first_token = command.strip().split(" ", 1)[0] if command.strip() else command
+    return f"{first_token} — {reason}"
+
+
+def analyze_friction(project_dir, days=30):
+    """Scan `project_dir`'s transcripts and return a friction report dict:
+
+    {
+      "total_calls": int,
+      "prompted_estimate": int,
+      "denied": int,
+      "patterns": [
+        {"pattern": str, "count": int, "sessions": int, "example": str},
+        ...
+      ],
+    }
+
+    Patterns are sorted by call count descending. `sessions` counts the
+    number of distinct sessions a pattern appeared in — the basis for the
+    "seen in >= 2 sessions" recurring-pattern rule used by /retro.
+    """
+    allow_rules, deny_rules = load_allow_rules(project_dir)
+    tool_uses = collect_bash_tool_uses(project_dir, days)
+    denied_tool_use_ids = {tid for _sid, tid in iter_denied_tool_use_ids(project_dir, days)}
+
+    pattern_counts = {}
+    pattern_sessions = {}
+    pattern_examples = {}
+    denied = 0
+
+    for entry in tool_uses:
+        command = entry["command"]
+        session_id = entry["session_id"]
+
+        if entry["tool_use_id"] in denied_tool_use_ids:
+            denied += 1
+
+        would_prompt, reason = classify_command(command, allow_rules, deny_rules)
+        if not would_prompt:
+            continue
+
+        key = _pattern_key(command, reason)
+        pattern_counts[key] = pattern_counts.get(key, 0) + 1
+        pattern_sessions.setdefault(key, set()).add(session_id)
+        pattern_examples.setdefault(key, command)
+
+    patterns = [
+        {
+            "pattern": key,
+            "count": count,
+            "sessions": len(pattern_sessions[key]),
+            "example": pattern_examples[key],
+        }
+        for key, count in pattern_counts.items()
+    ]
+    patterns.sort(key=lambda p: p["count"], reverse=True)
+
+    return {
+        "total_calls": len(tool_uses),
+        "prompted_estimate": sum(p["count"] for p in patterns),
+        "denied": denied,
+        "patterns": patterns,
+    }
+
+
+def format_report_text(report, days):
+    lines = [
+        f"Permission friction report (last {days} days)",
+        f"  Total Bash calls:        {report['total_calls']}",
+        f"  Estimated prompted:      {report['prompted_estimate']}",
+        f"  Explicit denials:        {report['denied']}",
+    ]
+
+    if report["patterns"]:
+        lines.append("")
+        lines.append("  Top prompt-causing patterns:")
+        for p in report["patterns"][:10]:
+            recurring = " [recurring: seen in >= 2 sessions]" if p["sessions"] >= 2 else ""
+            lines.append(
+                f"    {p['count']:>3}x  {p['pattern']}  (sessions: {p['sessions']}){recurring}"
+            )
+            lines.append(f"           e.g. {p['example']}")
+    else:
+        lines.append("")
+        lines.append("  No prompt-causing patterns found.")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan Claude Code session transcripts for permission friction.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                        Scan the current project, last 30 days
+  %(prog)s /path/to/project       Scan a specific project directory
+  %(prog)s --days 7               Narrow the scan window
+  %(prog)s --json                 Output as JSON
+        """,
+    )
+    parser.add_argument(
+        "project_dir",
+        nargs="?",
+        default=os.getcwd(),
+        help="Project root directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="How many days of transcript history to scan (default: 30)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output in JSON format",
+    )
+
+    args = parser.parse_args()
+
+    report = analyze_friction(args.project_dir, args.days)
+
+    if args.json_output:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report_text(report, args.days))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/permission-friction.py
+++ b/bin/permission-friction.py
@@ -111,3 +111,59 @@ def matches_bash_rule(command, rule):
 
 def command_matches_any_rule(command, rules):
     return any(matches_bash_rule(command, rule) for rule in rules)
+
+
+# Friction reasons, most specific first — used both to explain a verdict
+# and to bucket "top prompt-causing patterns" in the report.
+REASON_DENY_MATCH = "matches a deny rule"
+REASON_HEREDOC = "heredoc (<<, <<<) defeats matching"
+REASON_PROCESS_SUBSTITUTION = "process substitution (<(...), >(...)) defeats matching"
+REASON_COMMAND_SUBSTITUTION = "command substitution ($(...), `...`) defeats matching"
+REASON_CD_PREFIX = "cd-prefix defeats first-token matching"
+REASON_CHAIN = "compound command (;/&&/||/|) has an unmatched segment"
+REASON_NO_RULE = "no allow rule covers this command"
+
+
+def classify_command(command, allow_rules, deny_rules):
+    """Classify whether `command` would trigger a permission prompt.
+
+    Returns (would_prompt: bool, reason: str | None). reason is None only
+    when the command would NOT prompt. Mirrors hook-auto-approve-bash.py's
+    own safety logic first — a command that hook would silently approve
+    never reaches a prompt in practice, regardless of raw rule coverage.
+    """
+    if command_matches_any_rule(command, deny_rules):
+        return True, REASON_DENY_MATCH
+
+    if _hook.is_command_safe(command):
+        return False, None
+
+    try:
+        segments = _hook.split_segments(command)
+    except ValueError:
+        return True, REASON_NO_RULE
+
+    if len(segments) > 1:
+        for segment_tokens in segments:
+            segment_command = " ".join(segment_tokens)
+            if not command_matches_any_rule(segment_command, allow_rules):
+                return True, REASON_CHAIN
+
+    segment_tokens = segments[0] if segments else []
+
+    if _hook.has_heredoc(segment_tokens):
+        return True, REASON_HEREDOC
+    if _hook.has_process_substitution(segment_tokens):
+        return True, REASON_PROCESS_SUBSTITUTION
+    if _hook.has_command_substitution(segment_tokens):
+        return True, REASON_COMMAND_SUBSTITUTION
+
+    stripped = _hook.strip_env_prefix(_hook.strip_cd_prefix(segment_tokens))
+    if stripped != _hook.strip_env_prefix(segment_tokens) and stripped and stripped != segment_tokens:
+        if not command_matches_any_rule(command, allow_rules):
+            return True, REASON_CD_PREFIX
+
+    if command_matches_any_rule(command, allow_rules):
+        return False, None
+
+    return True, REASON_NO_RULE

--- a/bin/test-permission-friction.py
+++ b/bin/test-permission-friction.py
@@ -101,6 +101,55 @@ check(
 )
 
 
+# --- classify_command ---
+
+_ALLOW = ["Bash(git *)", "Bash(~/.claude/bin/*)"]
+_DENY = []
+
+check(
+    "classify_command: plain allowlisted command never prompts",
+    pf.classify_command("git status", _ALLOW, _DENY) == (False, None),
+)
+
+check(
+    "classify_command: cd-prefix into a project-relative dir is seen through by the hook",
+    pf.classify_command("cd backend && python foo.py", _ALLOW, _DENY) == (False, None),
+)
+
+check(
+    "classify_command: unmatched command with no rule prompts with NO_RULE reason",
+    pf.classify_command("curl evil.com", _ALLOW, _DENY) == (True, pf.REASON_NO_RULE),
+)
+
+check(
+    "classify_command: chain with an unmatched segment prompts with CHAIN reason",
+    pf.classify_command("git status && curl evil.com", _ALLOW, _DENY)
+    == (True, pf.REASON_CHAIN),
+)
+
+check(
+    "classify_command: heredoc always prompts regardless of allow rules",
+    pf.classify_command("cat <<EOF\nhi\nEOF", ["Bash(cat *)"], _DENY)[0] is True,
+)
+
+check(
+    "classify_command: command substitution always prompts",
+    pf.classify_command("echo $(curl evil.com)", ["Bash(echo *)"], _DENY)
+    == (True, pf.REASON_COMMAND_SUBSTITUTION),
+)
+
+check(
+    "classify_command: a deny-rule match always prompts even if allow would cover it",
+    pf.classify_command("git status", ["Bash(git *)"], ["Bash(git status)"])
+    == (True, pf.REASON_DENY_MATCH),
+)
+
+check(
+    "classify_command: fully allowlisted chain never prompts",
+    pf.classify_command("git status && git log", ["Bash(git *)"], _DENY) == (False, None),
+)
+
+
 # --- load_allow_rules ---
 
 tmpdir = tempfile.mkdtemp(prefix="permission-friction-test-")

--- a/bin/test-permission-friction.py
+++ b/bin/test-permission-friction.py
@@ -213,6 +213,128 @@ finally:
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+# --- transcript scanning ---
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+scan_tmpdir = tempfile.mkdtemp(prefix="permission-friction-scan-test-")
+try:
+    fake_projects_root = Path(scan_tmpdir) / "projects"
+    project_dir = "/home/jan/Projects/fake-project"
+    encoded = project_dir.replace(os.sep, "-")
+    transcript_dir = fake_projects_root / encoded
+    transcript_dir.mkdir(parents=True)
+
+    now = datetime.now(timezone.utc)
+    recent_ts = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    old_ts = (now - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+
+    session_a = transcript_dir / "session-a.jsonl"
+    session_a.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": recent_ts,
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "toolu_1",
+                                    "name": "Bash",
+                                    "input": {"command": "git status"},
+                                }
+                            ]
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": recent_ts,
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "toolu_1",
+                                    "content": "The user doesn't want to proceed with this tool use.",
+                                }
+                            ]
+                        },
+                    }
+                ),
+                # non-Bash tool_use must be ignored
+                json.dumps(
+                    {
+                        "timestamp": recent_ts,
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "toolu_2",
+                                    "name": "Read",
+                                    "input": {"file_path": "/tmp/x"},
+                                }
+                            ]
+                        },
+                    }
+                ),
+                # entry outside the days window must be excluded
+                json.dumps(
+                    {
+                        "timestamp": old_ts,
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "toolu_3",
+                                    "name": "Bash",
+                                    "input": {"command": "curl evil.com"},
+                                }
+                            ]
+                        },
+                    }
+                ),
+                # malformed line must not crash the scanner
+                "{not valid json",
+            ]
+        )
+    )
+
+    original_transcripts_dir = pf.PROJECTS_TRANSCRIPTS_DIR
+    pf.PROJECTS_TRANSCRIPTS_DIR = fake_projects_root
+    try:
+        tool_uses = pf.collect_bash_tool_uses(project_dir, days=30)
+        denied_ids = list(pf.iter_denied_tool_use_ids(project_dir, days=30))
+    finally:
+        pf.PROJECTS_TRANSCRIPTS_DIR = original_transcripts_dir
+
+    check(
+        "collect_bash_tool_uses only returns Bash tool_use entries within the window",
+        [t["command"] for t in tool_uses] == ["git status"],
+    )
+    check(
+        "collect_bash_tool_uses excludes entries older than the days window",
+        "curl evil.com" not in [t["command"] for t in tool_uses],
+    )
+    check(
+        "iter_denied_tool_use_ids finds the explicit rejection marker",
+        denied_ids == [("session-a", "toolu_1")],
+    )
+
+    # missing transcript dir must not crash, just yield nothing
+    pf.PROJECTS_TRANSCRIPTS_DIR = fake_projects_root
+    try:
+        empty_result = pf.collect_bash_tool_uses("/no/such/project", days=30)
+    finally:
+        pf.PROJECTS_TRANSCRIPTS_DIR = original_transcripts_dir
+    check(
+        "collect_bash_tool_uses returns empty list for missing transcript dir",
+        empty_result == [],
+    )
+finally:
+    shutil.rmtree(scan_tmpdir, ignore_errors=True)
+
+
 print(f"\n{passed} passed, {failed} failed")
 if failed:
     raise SystemExit(1)

--- a/bin/test-permission-friction.py
+++ b/bin/test-permission-friction.py
@@ -335,6 +335,119 @@ finally:
     shutil.rmtree(scan_tmpdir, ignore_errors=True)
 
 
+# --- analyze_friction end-to-end ---
+
+e2e_tmpdir = tempfile.mkdtemp(prefix="permission-friction-e2e-test-")
+try:
+    fake_home = Path(e2e_tmpdir) / "home"
+    fake_home.mkdir(parents=True)
+    (fake_home / "settings.json").write_text(
+        json.dumps({"permissions": {"allow": ["Bash(git *)"], "deny": []}})
+    )
+
+    fake_projects_root = Path(e2e_tmpdir) / "projects"
+    project_dir = "/home/jan/Projects/fake-e2e-project"
+    encoded = project_dir.replace(os.sep, "-")
+    transcript_dir = fake_projects_root / encoded
+    transcript_dir.mkdir(parents=True)
+
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+
+    def _bash_line(tool_id, command):
+        return json.dumps(
+            {
+                "timestamp": ts,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": "Bash",
+                            "input": {"command": command},
+                        }
+                    ]
+                },
+            }
+        )
+
+    def _denial_line(tool_id):
+        return json.dumps(
+            {
+                "timestamp": ts,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": "The user doesn't want to proceed with this tool use.",
+                        }
+                    ]
+                },
+            }
+        )
+
+    # session 1: two curl calls (unmatched, one denied), one clean git call
+    (transcript_dir / "session-1.jsonl").write_text(
+        "\n".join(
+            [
+                _bash_line("t1", "curl evil.com"),
+                _denial_line("t1"),
+                _bash_line("t2", "curl good.com"),
+                _bash_line("t3", "git status"),
+            ]
+        )
+    )
+    # session 2: another curl call (unmatched) -> pattern recurs across 2 sessions
+    (transcript_dir / "session-2.jsonl").write_text(
+        "\n".join([_bash_line("t4", "curl third.com")])
+    )
+
+    original_claude_home = pf.CLAUDE_HOME
+    original_transcripts_dir = pf.PROJECTS_TRANSCRIPTS_DIR
+    pf.CLAUDE_HOME = fake_home
+    pf.PROJECTS_TRANSCRIPTS_DIR = fake_projects_root
+    try:
+        report = pf.analyze_friction(project_dir, days=30)
+    finally:
+        pf.CLAUDE_HOME = original_claude_home
+        pf.PROJECTS_TRANSCRIPTS_DIR = original_transcripts_dir
+
+    check("analyze_friction: total_calls counts every Bash tool_use", report["total_calls"] == 4)
+    check(
+        "analyze_friction: prompted_estimate excludes the allowlisted git call",
+        report["prompted_estimate"] == 3,
+    )
+    check("analyze_friction: denied counts the one rejected call", report["denied"] == 1)
+    check("analyze_friction: exactly one pattern group (curl, NO_RULE)", len(report["patterns"]) == 1)
+    curl_pattern = report["patterns"][0]
+    check("analyze_friction: curl pattern count is 3", curl_pattern["count"] == 3)
+    check(
+        "analyze_friction: curl pattern recurs across both sessions",
+        curl_pattern["sessions"] == 2,
+    )
+
+    text_report = pf.format_report_text(report, days=30)
+    check("format_report_text: mentions recurring marker for sessions>=2", "recurring" in text_report)
+    check("format_report_text: includes total call count", "4" in text_report)
+
+    # graceful handling of a project with no transcripts at all (AC requirement)
+    pf.CLAUDE_HOME = fake_home
+    pf.PROJECTS_TRANSCRIPTS_DIR = fake_projects_root
+    try:
+        empty_report = pf.analyze_friction("/home/jan/Projects/never-scanned", days=30)
+    finally:
+        pf.CLAUDE_HOME = original_claude_home
+        pf.PROJECTS_TRANSCRIPTS_DIR = original_transcripts_dir
+
+    check(
+        "analyze_friction: empty/missing transcript dir yields a zeroed report, not a crash",
+        empty_report == {"total_calls": 0, "prompted_estimate": 0, "denied": 0, "patterns": []},
+    )
+finally:
+    shutil.rmtree(e2e_tmpdir, ignore_errors=True)
+
+
 print(f"\n{passed} passed, {failed} failed")
 if failed:
     raise SystemExit(1)

--- a/bin/test-permission-friction.py
+++ b/bin/test-permission-friction.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Standalone tests for permission-friction.py.
+
+Run directly: python3 bin/test-permission-friction.py
+Or via venv: ~/.claude/bin/venv-run.sh python bin/test-permission-friction.py
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parent / "permission-friction.py"
+
+spec = importlib.util.spec_from_file_location("permission_friction", SCRIPT_PATH)
+pf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pf)
+
+passed = 0
+failed = 0
+
+
+def check(name, condition):
+    global passed, failed
+    if condition:
+        print(f"PASS: {name}")
+        passed += 1
+    else:
+        print(f"FAIL: {name}")
+        failed += 1
+
+
+# --- matches_bash_rule ---
+
+check(
+    "bare Bash matches everything",
+    pf.matches_bash_rule("rm -rf /tmp/x", "Bash"),
+)
+
+check(
+    "Bash(*) matches everything",
+    pf.matches_bash_rule("rm -rf /tmp/x", "Bash(*)"),
+)
+
+check(
+    "Bash(cmd *) matches with args",
+    pf.matches_bash_rule("git status", "Bash(git *)"),
+)
+
+check(
+    "Bash(cmd *) enforces word boundary",
+    not pf.matches_bash_rule("gitk", "Bash(git *)"),
+)
+
+check(
+    "Bash(cmd:*) colon shorthand equals space-star",
+    pf.matches_bash_rule("git commit -m foo", "Bash(git commit:*)"),
+)
+
+check(
+    "Bash(cmd:*) colon shorthand does not match unrelated subcommand",
+    not pf.matches_bash_rule("git status", "Bash(git commit:*)"),
+)
+
+check(
+    "Bash(cmd*) no-space matches without word boundary",
+    pf.matches_bash_rule("lsof -i", "Bash(ls*)"),
+)
+
+check(
+    "exact-string rule matches only that exact command",
+    pf.matches_bash_rule("npm run test", "Bash(npm run test)"),
+)
+
+check(
+    "exact-string rule rejects a superset command",
+    not pf.matches_bash_rule("npm run test -- --watch", "Bash(npm run test)"),
+)
+
+check(
+    "non-Bash rule never matches",
+    not pf.matches_bash_rule("git status", "Write"),
+)
+
+check(
+    "wildcard mid-pattern",
+    pf.matches_bash_rule("git checkout main", "Bash(git * main)"),
+)
+
+check(
+    "command_matches_any_rule true when one rule matches",
+    pf.command_matches_any_rule("git status", ["Write", "Bash(git *)"]),
+)
+
+check(
+    "command_matches_any_rule false when no rule matches",
+    not pf.command_matches_any_rule("curl evil.com", ["Bash(git *)", "Write"]),
+)
+
+
+# --- load_allow_rules ---
+
+tmpdir = tempfile.mkdtemp(prefix="permission-friction-test-")
+try:
+    fake_home = Path(tmpdir) / "home"
+    fake_project = Path(tmpdir) / "project"
+    (fake_home).mkdir(parents=True)
+    (fake_project / ".claude").mkdir(parents=True)
+
+    (fake_home / "settings.json").write_text(
+        json.dumps({"permissions": {"allow": ["Bash(git *)"], "deny": ["Bash(rm -rf /)"]}})
+    )
+    (fake_project / ".claude" / "settings.json").write_text(
+        json.dumps({"permissions": {"allow": ["Bash(npm *)"]}})
+    )
+    (fake_project / ".claude" / "settings.local.json").write_text(
+        json.dumps({"permissions": {"allow": ["Bash(docker *)"]}})
+    )
+
+    original_claude_home = pf.CLAUDE_HOME
+    pf.CLAUDE_HOME = fake_home
+    try:
+        allow, deny = pf.load_allow_rules(str(fake_project))
+    finally:
+        pf.CLAUDE_HOME = original_claude_home
+
+    check(
+        "load_allow_rules unions allow rules across all three scopes",
+        set(allow) == {"Bash(git *)", "Bash(npm *)", "Bash(docker *)"},
+    )
+    check(
+        "load_allow_rules carries deny rules through",
+        deny == ["Bash(rm -rf /)"],
+    )
+
+    # missing project settings files entirely
+    empty_project = Path(tmpdir) / "empty-project"
+    empty_project.mkdir()
+    pf.CLAUDE_HOME = fake_home
+    try:
+        allow2, deny2 = pf.load_allow_rules(str(empty_project))
+    finally:
+        pf.CLAUDE_HOME = original_claude_home
+
+    check(
+        "load_allow_rules falls back to just global scope when project settings missing",
+        allow2 == ["Bash(git *)"] and deny2 == ["Bash(rm -rf /)"],
+    )
+
+    # malformed JSON file must not crash the loader
+    malformed_project = Path(tmpdir) / "malformed-project"
+    (malformed_project / ".claude").mkdir(parents=True)
+    (malformed_project / ".claude" / "settings.json").write_text("{not valid json")
+    pf.CLAUDE_HOME = fake_home
+    try:
+        allow3, deny3 = pf.load_allow_rules(str(malformed_project))
+        check("load_allow_rules tolerates malformed settings.json", allow3 == ["Bash(git *)"])
+    finally:
+        pf.CLAUDE_HOME = original_claude_home
+finally:
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+print(f"\n{passed} passed, {failed} failed")
+if failed:
+    raise SystemExit(1)

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -42,6 +42,28 @@ For each finding, summarise:
 
 If the session had no knowledge worth capturing, say so. Do not invent artefacts.
 
+## Phase 1b: Permission Friction
+
+Run the friction scanner to surface allowlist gaps the conversation itself won't mention:
+
+```bash
+python3 ~/.claude/bin/permission-friction.py --days 30
+```
+
+(Or via venv: `~/.claude/bin/venv-run.sh python ~/.claude/bin/permission-friction.py --days 30`.)
+
+This scans the current project's transcripts and reports total Bash calls, an estimated prompted count, explicit denials, and the top prompt-causing patterns — grouped by command and the specific construct that defeated matching (no allow rule, unmatched chain segment, `cd`-prefix, command substitution, heredoc). No hardcoded allowlist: it derives rules live from the merged global + project + local `settings.json` files.
+
+**The rule: a pattern seen in >= 2 sessions is a candidate for enforcement, not documentation.** Per the code-review rule ("a convention violated more than once is a hook, not a docs line"), for each pattern the report flags as recurring (`sessions >= 2`), propose ONE concrete remedy in the retro summary:
+
+- **Allowlist rule** — a missing `Bash(cmd *)` entry that would cover the pattern outright (safe, read-only, or already-reviewed commands)
+- **`bin/` wrapper script** — for compound commands (`&&`, `;`, `|` chains) that keep defeating first-token matching; wrap the sequence so permissions match on the wrapper path instead
+- **Hook change** — for patterns already handled case-by-case by `hook-auto-approve-bash.py` logic elsewhere, extend that hook instead of adding narrow allowlist entries
+
+If the report finds no recurring patterns (all counts are 1, or `patterns` is empty), say so — do not invent a remedy for single-occurrence noise.
+
+For one-off, low-risk **read-only** allowlist gaps that don't recur, mention the built-in `/fewer-permission-prompts` skill as the quick path — it scans transcripts and proposes a prioritized allowlist addition directly, without going through a full retro.
+
 ## Phase 2: Classify Each Finding
 
 Assign each finding to exactly one category:
@@ -145,6 +167,9 @@ Group output into sections:
 
 ### Toolkit candidates (if any)
 - <name>: <one-line description> → ~/.claude/toolkit-proposals/<name>.md
+
+### Permission friction (if any recurring patterns found)
+- <pattern>: seen in N sessions → proposed remedy (allowlist rule / bin/ wrapper / hook change)
 ```
 
 **Wait for confirmation before making any changes.**


### PR DESCRIPTION
Closes #14

## Summary

Adds `bin/permission-friction.py`, a standalone script that scans the current project's Claude Code session transcripts and reports permission friction: total Bash calls, an estimated prompted count, explicit denials, and the top prompt-causing patterns grouped by command and the specific construct that defeated matching (no allow rule, unmatched chain segment, `cd`-prefix, command/process substitution, heredoc).

Allow/deny rules are parsed live from the merged `~/.claude/settings.json`, `<project>/.claude/settings.json`, and `<project>/.claude/settings.local.json` files — never hardcoded, so the report stays accurate as permissions evolve. The classifier reuses `hook-auto-approve-bash.py`'s existing tokenization and safety logic rather than duplicating it, so a command the hook already silently approves is correctly never counted as friction.

There is no direct transcript signal for "a prompt was shown and approved" — only an explicit denial leaves a trace (a `tool_result` carrying the "user doesn't want to proceed" rejection text). So "prompted" is estimated as any Bash call that doesn't match an allow rule (per user decision during planning), while "denied" is counted exactly from that marker.

`/retro`'s SKILL.md gains a new "Phase 1b: Permission Friction" phase that runs the script and, for any pattern recurring in ≥2 sessions, proposes a concrete remedy (allowlist rule, `bin/` wrapper, or hook change) per the existing code-review rule ("a convention violated more than once is a hook, not a docs line"). It also points to the built-in `/fewer-permission-prompts` skill as the quick path for one-off read-only allowlist gaps.

## Test checklist

- [x] `bin/test-permission-friction.py` — 38/38 passing
- [x] `bin/test-hook-auto-approve-bash.py` — 63/63 passing (unaffected by the new script importing it)
- [x] Manual run against this repo's own transcripts (`--days 60`, `--json`) — produces a coherent report
- [x] Manual run against a nonexistent project dir — exits cleanly with a zeroed report, no traceback

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `bin/permission-friction.py` runs standalone in any project and produces the report from transcripts only (no network) | ✅ |
| 2 | Allow rules are derived from settings files at runtime, not hardcoded | ✅ |
| 3 | Retro SKILL.md has the new phase, including the "seen twice ⇒ propose enforcement" rule | ✅ |
| 4 | Script handles missing/empty transcript dirs gracefully | ✅ |
