### PR TITLE
Secret scanning: gitleaks pre-commit hook + GitHub push protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ This creates five symlinks and copies one file:
 
 The settings file is copied (not symlinked) because Claude Code writes to it when you approve permissions during a session. Restart Claude Code after installation.
 
+This repo is public, so it also ships a [pre-commit](https://pre-commit.com/) hook that scans staged changes for secrets with [gitleaks](https://github.com/gitleaks/gitleaks) before every commit. Install it once per clone:
+
+```bash
+pip install --user pre-commit
+pre-commit install
+```
+
+Without running `pre-commit install`, the hook is present in the repo but never fires — it must be installed per clone.
+
 Skills are auto-discovered from `~/.claude/skills/*/SKILL.md`. Agents are auto-discovered from `~/.claude/agents/*.md`.
 
 ### Project Template
@@ -136,6 +145,8 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `secret-scan.sh` | `secret-scan.sh [project-dir]` | Scan codebase for hardcoded secrets, API keys, tokens |
 | `security-headers-check.sh` | `security-headers-check.sh <url>` | Check HTTP security headers (CSP, HSTS, X-Frame-Options, etc.) |
 | `owasp-zap-scan.sh` | `owasp-zap-scan.sh <url>` | OWASP ZAP baseline scan via Docker (requires running target) |
+
+`secret-scan.sh` and the `gitleaks` pre-commit hook (see Installation) are intentionally separate tools, not a pattern list to keep in sync: `secret-scan.sh` is an on-demand audit invoked manually or via `/security-audit`, while `gitleaks` is a commit-time gate that blocks `git commit` outright when it finds a match.
 
 ### Runtime verification
 


### PR DESCRIPTION
Closes #23

## Summary

Adds the two prevention layers this public repo was missing: a local pre-commit secret-scanning gate and GitHub's native secret scanning + push protection. Also runs the required one-time full-history scan.

- **Pre-commit hook**: `.pre-commit-config.yaml` wires the official [gitleaks](https://github.com/gitleaks/gitleaks) pre-commit hook (`v8.30.1`). Blocks `git commit` when a secret-shaped string is staged.
- **GitHub settings**: enabled `secret_scanning` and `secret_scanning_push_protection` on `ImperialAutomation/claude-code-toolkit` via the GitHub API.
- **History scan**: ran `gitleaks detect --source . --log-opts="--all"` against all 136 commits — **clean, no leaks found**. No follow-up incident issue needed.
- **Docs**: README now documents the `pre-commit install` step (Installation section) and explicitly notes that `bin/secret-scan.sh` (on-demand audit, used by `/security-audit`) and the new gitleaks hook (commit-time gate) are intentionally separate tools, not a pattern list to keep in sync.

## Test checklist

Functional verification (this is a config/tooling issue — no app test suite applies):

- [x] Hook installed via `pre-commit install`; `.git/hooks/pre-commit` confirmed generated by the pre-commit framework
- [x] Blocks a real commit: staged a fake Stripe-style secret, `git commit` failed (exit 1, gitleaks reported the finding); scratch file removed before this PR, never entered history
- [x] Passes a clean commit: both commits in this PR passed the hook ("Detect hardcoded secrets.....Passed")
- [x] GitHub API confirms `secret_scanning.status: enabled` and `secret_scanning_push_protection.status: enabled`
- [x] Full-history scan: 136 commits scanned, 0 leaks
- [x] README documents both the install step and the secret-scan.sh/gitleaks split

All 6/6 acceptance criteria independently verified by a fresh sub-agent pass — see verification summary (AC_VERIFIED: 6/6, REVIEW: PASS, TESTS: PASS).

## Out of scope (per issue)

- `dependabot_security_updates` remains disabled — not in the original acceptance criteria, flagged as a possible fast-follow
- No findings from the history scan, so no incident-response issue was needed
