### PR TITLE
feat(stripe-testing): add Stripe test-value skill and rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ claude-code-instructie-*.md
 implement-retro-promote-sync.md
 __pycache__/
 *.pyc
+
+# Codex-managed skills, not part of this toolkit
+skills/.system/

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Symlinked to `~/.claude/CLAUDE.md`, applies to all projects. Contains only what'
 - **Available Utilities** — references to wrapper scripts and audit skills
 - **Claude Code Workarounds** — native tool preferences, file writing rules
 
-Contextual rules live in `rules/` and load based on their frontmatter: some always (error handling, API design, data integrity, structured logging, code review), others only when relevant files are edited (testing, documentation).
+Contextual rules live in `rules/` and load based on their frontmatter: some always (error handling, API design, data integrity, structured logging, code review), others only when relevant files are edited (testing, documentation, stripe-testing).
 
 ### Rules (`rules/`)
 
@@ -322,6 +322,7 @@ Rules provide contextual policies that load based on frontmatter configuration. 
 | `code-review.md` | Always | No performative agreement, verify before implementing, push back when feedback is wrong |
 | `testing.md` | Test files | Real behavior over mocks, 5 test scenarios per feature, realistic fixtures |
 | `documentation.md` | .md files | Current purpose over history, usage guidance, no changelogs |
+| `stripe-testing.md` | Payment/billing/webhook files | Never real cards, no raw PANs in code, assert on decline codes, prove webhook idempotency |
 
 ### Project Template (`claude-md/project-template.md`)
 
@@ -364,6 +365,7 @@ Global permissions (git, gh, edit, file operations) are in `~/.claude/settings.j
 | `/test` | `/test [--all\|--affected]` | Smart test runner that scopes tests based on changed files |
 | `/pre-merge` | `/pre-merge` | Combined quality gate — orchestrates review, tests, verification, AC checks |
 | `/sync-toolkit` | `/sync-toolkit <pull\|status\|drift>` | Sync toolkit across devices from configured git sources |
+| `/stripe-testing` | `/stripe-testing` | Stripe test values — cards, declines, 3DS, disputes, refunds, SEPA/ACH, webhooks |
 
 ---
 

--- a/bin/git-verify.sh
+++ b/bin/git-verify.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Read-only git status snapshot in one call — avoids a permission prompt per
+# individual command, which is the dominant friction during long epic runs.
+#
+# Usage: git-verify.sh [repo-dir] [--base <branch>] [--alembic]
+#   repo-dir   defaults to the current directory
+#   --base     also show commits on HEAD not in <branch>, and vice versa
+#   --alembic  also show alembic heads (fails loudly if more than one)
+#
+# Examples:
+#   git-verify.sh
+#   git-verify.sh ~/Projects/Acme --base develop --alembic
+#
+# Read-only by design: it never writes, fetches, checks out or stashes.
+set -euo pipefail
+
+repo="."
+base=""
+want_alembic=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)    base="${2:-}"; shift 2 ;;
+    --alembic) want_alembic=1; shift ;;
+    -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
+    *)         repo="$1"; shift ;;
+  esac
+done
+
+[[ -d "$repo" ]] || { echo "git-verify: no such directory: $repo" >&2; exit 1; }
+git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "git-verify: not a git repository: $repo" >&2; exit 1; }
+
+branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+echo "=== branch ==="
+echo "$branch"
+
+echo
+echo "=== uncommitted (tracked) ==="
+# Untracked files are omitted: sandbox dotfile-masking makes that list noisy.
+if [[ -n "$(git -C "$repo" status --short --untracked-files=no)" ]]; then
+  git -C "$repo" status --short --untracked-files=no
+else
+  echo "(clean)"
+fi
+
+echo
+echo "=== recent commits ==="
+git -C "$repo" log --oneline -5
+
+upstream="$(git -C "$repo" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)"
+if [[ -n "$upstream" ]]; then
+  echo
+  echo "=== vs upstream ($upstream) ==="
+  ahead=$(git -C "$repo" rev-list --count "$upstream..HEAD" 2>/dev/null || echo "?")
+  behind=$(git -C "$repo" rev-list --count "HEAD..$upstream" 2>/dev/null || echo "?")
+  echo "ahead: $ahead   behind: $behind"
+  # Unpushed work is the thing worth seeing at a glance: it is what a dying
+  # background agent loses.
+  if [[ "$ahead" != "0" && "$ahead" != "?" ]]; then
+    git -C "$repo" log --oneline "$upstream..HEAD"
+  fi
+else
+  echo
+  echo "=== vs upstream ==="
+  echo "(no upstream configured — nothing pushed yet)"
+fi
+
+if [[ -n "$base" ]]; then
+  echo
+  echo "=== vs $base ==="
+  if git -C "$repo" rev-parse --verify --quiet "$base" >/dev/null; then
+    n=$(git -C "$repo" rev-list --count "$base..HEAD")
+    echo "commits on HEAD not in $base: $n"
+    # Capped: a long-running feature branch can be 50+ commits ahead, and
+    # dumping them all is the context cost this script exists to avoid.
+    if [[ "$n" != "0" ]]; then
+      git -C "$repo" log --oneline -10 "$base..HEAD"
+      if [[ "$n" -gt 10 ]]; then echo "... and $((n - 10)) more"; fi
+    fi
+  else
+    echo "(branch not found: $base)"
+  fi
+fi
+
+stashes=$(git -C "$repo" stash list 2>/dev/null || true)
+if [[ -n "$stashes" ]]; then
+  echo
+  echo "=== stashes ==="
+  echo "$stashes"
+fi
+
+worktrees=$(git -C "$repo" worktree list 2>/dev/null | tail -n +2 || true)
+if [[ -n "$worktrees" ]]; then
+  echo
+  echo "=== extra worktrees ==="
+  echo "$worktrees"
+fi
+
+if [[ "$want_alembic" -eq 1 ]]; then
+  echo
+  echo "=== alembic heads ==="
+  alembic_bin=""
+  for candidate in "$repo/backend/.venv/bin/alembic" "$repo/.venv/bin/alembic"; do
+    [[ -x "$candidate" ]] && { alembic_bin="$candidate"; break; }
+  done
+  if [[ -z "$alembic_bin" ]]; then
+    echo "(no venv alembic found)"
+  else
+    alembic_dir=$(dirname "$(dirname "$(dirname "$alembic_bin")")")
+    heads=$("$alembic_bin" -c "$alembic_dir/alembic.ini" heads 2>&1 | grep -c "(head)" || true)
+    "$alembic_bin" -c "$alembic_dir/alembic.ini" heads 2>&1 | tail -5
+    # More than one head means a branched revision history — it breaks every
+    # later migration in the run, so surface it rather than letting it pass.
+    [[ "$heads" -gt 1 ]] && echo "WARNING: $heads heads — revision history has branched"
+  fi
+fi
+
+exit 0

--- a/rules/stripe-testing.md
+++ b/rules/stripe-testing.md
@@ -1,0 +1,39 @@
+---
+paths: "**/*stripe*, **/*payment*, **/*billing*, **/*checkout*, **/*subscription*"
+---
+
+# Stripe Testing
+
+Non-negotiables when testing a Stripe integration. Full test-value tables
+(cards, PaymentMethods, SEPA/ACH accounts, 3DS, disputes) live in the
+`stripe-testing` skill — invoke it when you need a specific value.
+
+- **Never use real card details in test mode.** The Stripe Services Agreement
+  prohibits it. Use test API keys plus the documented test values, always.
+- **Never put raw card numbers in API calls or server-side code** — not even in
+  tests. Use a test `PaymentMethod` (`pm_card_visa`, `pm_card_visa_chargeDeclined`,
+  …). Raw PANs in server code put the integration outside PCI scope compliance
+  when the same code path goes live. Raw numbers are for interactive entry in a
+  payment form only.
+- **Test keys and live keys are separate worlds.** Test keys can't process live
+  payments and live keys must never appear in source, config files, or a
+  lockfile — environment variables or a secrets vault only.
+- **A test sandbox is not a load-test target.** Rate limits are *stricter* in
+  test mode than in live mode, so load testing produces `429`s you'd never see
+  in production and tells you nothing. See Stripe's load-testing guidance.
+- **Assert on the error/decline code, not on the message.** Decline test cards
+  return a stable `code` + `decline_code` pair (e.g. `card_declined` +
+  `insufficient_funds`); the human-readable message is not a contract.
+- **A check that can be skipped can't fail.** Stripe skips CVC, postal-code and
+  address verification when you omit those fields — so a test for "CVC check
+  fails" must actually send a CVC. Same for postal code and line1.
+- **Cover more than the happy path.** A payment integration needs at minimum:
+  success, a decline, a 3D Secure authentication flow, an asynchronous
+  refund, and a webhook replay. Card-success-only is not a tested integration.
+- **Webhook tests must prove idempotency.** Stripe delivers the same event more
+  than once; a test that fires each event exactly once will not catch a
+  double-charge. Deliver the same event ID twice and assert one effect.
+  (See data-integrity rule.)
+
+Source: [docs.stripe.com/testing](https://docs.stripe.com/testing) — verify
+against the live page when a value doesn't behave as documented.

--- a/skills/stripe-testing/SKILL.md
+++ b/skills/stripe-testing/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: stripe-testing
+description: "Stripe test values and testing procedures — test card numbers, PaymentMethod/token IDs, declines and decline codes, 3D Secure/SCA authentication cards, disputes and evidence values, async refunds, Radar/fraud simulation, SEPA Direct Debit and ACH test accounts, webhook triggering, and test-mode rate limits. TRIGGER — read before writing the code, not after: writing or debugging any test that touches Stripe; needing a specific test card number, pm_* or tok_* value; simulating a decline, dispute, refund, 3DS challenge, or fraud block; testing webhooks or subscription billing; a Stripe test behaving unexpectedly (payment succeeds when it should decline, 3DS not triggering, refund status not transitioning, 429s in test mode). SKIP when the work is a different PSP (Mollie, Adyen, PayPal, Braintree) or is Stripe production/onboarding work with no testing element — for PSP onboarding and integration architecture see the payments rule instead."
+user-invocable: true
+---
+
+# Stripe Testing
+
+Authoritative test values for simulating Stripe payments without moving funds.
+The hard rules (no real cards, no raw PANs in code, no load testing in a
+sandbox) are in the `stripe-testing` rule and load automatically — this skill
+carries the lookup tables.
+
+## How to use this skill
+
+1. **Identify the scenario** you need to simulate from the table below.
+2. **Read only the reference file that covers it** — they are large; don't load
+   all of them.
+3. **Prefer a `pm_*` PaymentMethod over a raw card number** in any API call or
+   server-side test. Raw numbers are for interactive payment-form entry only.
+
+| Scenario | Reference |
+|---|---|
+| Successful payment, by brand or by country | `references/cards-success.md` |
+| Decline, error code, fraud/Radar block, invalid data | `references/cards-decline.md` |
+| 3D Secure / SCA authentication, mobile challenge flows | `references/3d-secure.md` |
+| Dispute, chargeback, evidence, async refund, payout timing | `references/disputes-refunds.md` |
+| SEPA Direct Debit, ACH Direct Debit, microdeposits | `references/non-card.md` |
+| Webhooks, Stripe CLI, test clocks, rate limits, sandboxes | `references/workflow.md` |
+
+## The five values worth memorising
+
+Most testing needs only these; look up the rest.
+
+| Purpose | Value |
+|---|---|
+| Payment succeeds | `pm_card_visa` (number `4242424242424242`) |
+| Generic decline | `pm_card_visa_chargeDeclined` (number `4000000000000002`) |
+| Insufficient funds | `pm_card_visa_chargeDeclinedInsufficientFunds` (`4000000000009995`) |
+| 3DS authentication required | `pm_card_threeDSecure2Required` (`4000000000003220`) |
+| Dispute (fraudulent) | `pm_card_createDispute` (`4000000000000259`) |
+
+For interactive entry: any future expiry (e.g. **12/34**), any 3-digit CVC
+(4 for Amex), any value for the remaining fields.
+
+## Traps that cost debugging time
+
+- **A skipped check can't fail.** Omit the CVC and Stripe skips CVC
+  verification entirely — your "CVC check fails" test then passes for the wrong
+  reason. Send a CVC (any 3 digits), a postal code, or a line1 whenever you are
+  testing that specific check.
+- **Decline cards can't be attached to a Customer.** Attaching fails outright.
+  To test a customer whose charge later fails, use `pm_card_chargeCustomerFail`
+  (`4000000000000341`) — attaching succeeds, charging fails.
+- **3DS redirects don't happen for payments created in the Dashboard.** Drive
+  3DS tests from your own frontend or an API call, never from the Dashboard.
+- **`4242424242424242` is not a 3DS test card.** It's *unenrolled* — Stripe
+  returns `attempt_acknowledged` and skips the challenge, so a 3DS test built on
+  it silently proves nothing. Use a card from `references/3d-secure.md`.
+- **Async refunds don't fail immediately.** `pm_card_refundFail` starts as
+  `succeeded` and transitions to `failed` later via a `refund.failed` event —
+  asserting right after the refund call tests the wrong state.
+- **429s in test mode aren't a bug in your code.** Test-mode rate limits are
+  stricter than live. Slow the requests down; don't load-test a sandbox.
+- **Cross-border fees appear in test mode too**, based on the issuer country of
+  the test card (JCB, UnionPay, non-US cards). Unexpected fee amounts in a test
+  assertion often trace to the card's country, not to your fee logic.
+
+## Keeping this current
+
+These tables were captured from
+[docs.stripe.com/testing](https://docs.stripe.com/testing) on **2026-08-07**.
+Stripe adds test values over time and occasionally changes behavior. When a
+documented value doesn't behave as described, fetch the live page before
+concluding the integration is broken — the page is the source of truth, this is
+a cache.
+
+Coverage is deliberately partial in two places, both noted in the reference
+files: SEPA Direct Debit lists a representative subset of countries rather than
+all of them, and Terminal/in-person testing points at Stripe's dedicated
+Terminal testing page instead of duplicating it.

--- a/skills/stripe-testing/references/3d-secure.md
+++ b/skills/stripe-testing/references/3d-secure.md
@@ -1,0 +1,82 @@
+# Stripe test values — 3D Secure / SCA
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+All references are to 3D Secure 2.
+
+**Only the cards on this page meaningfully test a 3DS integration.** Other test
+cards may still trigger 3DS, but Stripe returns `attempt_acknowledged` and
+bypasses the challenge — a 3DS test built on `pm_card_visa` silently proves
+nothing.
+
+**3DS redirects do not occur for payments created in the Stripe Dashboard.**
+Drive these tests from your own frontend or an API call.
+
+## Authentication and setup behavior
+
+How the card behaves depends on whether it has been [set up](https://docs.stripe.com/payments/save-and-reuse)
+for future off-session payments.
+
+| Description | Number | PaymentMethod |
+|---|---|---|
+| Authenticate unless set up | 4000002500003155 | `pm_card_authenticationRequiredOnSetup` |
+| Always authenticate | 4000002760003184 | `pm_card_authenticationRequired` |
+| Already set up for off-session | 4000003800000446 | `pm_card_authenticationRequiredSetupForOffSession` |
+| Authenticates, then declines (insufficient funds) | 4000008260003178 | `pm_card_authenticationRequiredChargeDeclinedInsufficientFunds` |
+
+- **Authenticate unless set up** — off-session payments need authentication
+  until you set the card up; after setup they don't. On-session payments always
+  do.
+- **Always authenticate** — every transaction, regardless of setup state.
+- **Already set up** — one-time and on-session payments require authentication;
+  all off-session payments succeed as if previously set up.
+- **Insufficient funds** — authenticates successfully, then declines with
+  `insufficient_funds`. Use this to prove your code handles a decline *after* a
+  successful 3DS challenge.
+
+## Support and availability
+
+Authentication is requested when regulation, your Radar rules, or your own code
+demand it — but it can't always be performed. These cards simulate the
+combinations.
+
+| 3DS usage | Outcome | Number | PaymentMethod |
+|---|---|---|---|
+| Required | OK | 4000000000003220 (IE-issued) | `pm_card_threeDSecure2Required` |
+| Required | OK | 4000008400000027 (US-issued) | — |
+| Required | Declined after auth | 4000008400001629 | `pm_card_threeDSecureRequiredChargeDeclined` |
+| Required | Lookup processing error | 4000008400001280 | `pm_card_threeDSecureRequiredProcessingError` |
+| Supported (not required) | OK | 4000000000003055 | `pm_card_threeDSecureOptional` |
+| Supported (not required) | Processing error | 4000000000003097 | `pm_card_threeDSecureOptionalProcessingError` |
+| Supported | Unenrolled — no challenge | 4242424242424242 | `pm_card_visa` |
+| Not supported | Cannot be invoked | 378282246310005 | `pm_card_amex_threeDSecureNotSupported` |
+| Frictionless flow | OK | 4000000032200000 | — |
+
+"By default, your Radar rules request 3DS" applies to the *Required* rows; the
+*Supported* rows are not requested by default.
+
+Token equivalents: `tok_threeDSecure2Required`,
+`tok_threeDSecureRequiredChargeDeclined`, `tok_threeDSecureOptional`,
+`tok_amex_threeDSecureNotSupported`, etc.
+
+## Mobile challenge flows
+
+These trigger a specific challenge UI in a **mobile** payment. In browser-based
+forms or API calls they work but trigger no special behavior — so Stripe
+publishes no `pm_*` or `tok_*` equivalents.
+
+| Challenge flow | Number |
+|---|---|
+| Out of band | 4000582600000094 |
+| One time passcode | 4000582600000045 |
+| Single select | 4000582600000102 |
+| Multi select | 4000582600000110 |
+
+## SCA context
+
+Strong Customer Authentication has been in force since 14 September 2019 and
+requires two-factor authentication for many online payments in the European
+Economic Area. The per-country success cards in `cards-success.md` deliberately
+succeed *without* authentication — they do not exercise the SCA path. Test both.
+
+A dispute raised as **fraudulent** is protected after 3DS authentication; a
+**product not received** dispute is not. See `disputes-refunds.md`.

--- a/skills/stripe-testing/references/cards-decline.md
+++ b/skills/stripe-testing/references/cards-decline.md
@@ -1,0 +1,91 @@
+# Stripe test values — declines, errors and fraud
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+
+Assert on the `code` / `decline_code` pair, never on the human-readable
+message — the message is not a contract.
+
+## Issuer declines
+
+These return a card error with the listed error code and decline code.
+
+| Description | Number | PaymentMethod | Error code | Decline code |
+|---|---|---|---|---|
+| Generic decline | 4000000000000002 | `pm_card_visa_chargeDeclined` | `card_declined` | `generic_decline` |
+| Insufficient funds | 4000000000009995 | `pm_card_visa_chargeDeclinedInsufficientFunds` | `card_declined` | `insufficient_funds` |
+| Lost card | 4000000000009987 | `pm_card_visa_chargeDeclinedLostCard` | `card_declined` | `lost_card` |
+| Stolen card | 4000000000009979 | `pm_card_visa_chargeDeclinedStolenCard` | `card_declined` | `stolen_card` |
+| Expired card | 4000000000000069 | `pm_card_chargeDeclinedExpiredCard` | `expired_card` | n/a |
+| Incorrect CVC | 4000000000000127 | `pm_card_chargeDeclinedIncorrectCvc` | `incorrect_cvc` | n/a |
+| Processing error | 4000000000000119 | `pm_card_chargeDeclinedProcessingError` | `processing_error` | n/a |
+| Incorrect number | 4242424242424241 | — | `incorrect_number` | n/a |
+| Velocity limit exceeded | 4000000000006975 | `pm_card_visa_chargeDeclinedVelocityLimitExceeded` | `card_declined` | `card_velocity_exceeded` |
+
+**Trap:** these cards cannot be attached to a `Customer` — attaching fails
+outright. To test a stored customer whose charge later fails, use:
+
+| Description | Number | PaymentMethod |
+|---|---|---|
+| Decline after attaching | 4000000000000341 | `pm_card_chargeCustomerFail` |
+
+Attaching succeeds; every charge attempt then fails. Token variants add
+`tok_visa_chargeCustomerFailLostCard` and `tok_visa_chargeCustomerFailStolenCard`
+for lost/stolen-specific failure after attaching.
+
+Token equivalents follow the pattern `tok_visa_chargeDeclined*` /
+`tok_chargeDeclined*`.
+
+## Invalid data — no special card needed
+
+Any invalid value triggers these; you don't need a dedicated test card.
+
+| Error code | How to trigger |
+|---|---|
+| `invalid_expiry_month` | An invalid month, e.g. **13** |
+| `invalid_expiry_year` | A year up to 50 years in the past, e.g. **95** |
+| `invalid_cvc` | A two-digit number, e.g. **99** |
+| `incorrect_number` | A number failing the Luhn check, e.g. `4242424242424241` |
+
+## Radar / fraud simulation
+
+Blocked payments produce a card error with error code `fraud`. Whether a card is
+actually blocked depends on **your Radar settings** — only "Always blocked" is
+unconditional. A test asserting a block will therefore fail if the account's
+Radar rules differ; pin the expectation to the account config or use the
+always-blocked card.
+
+**Trap:** to test a *failing* CVC / postal-code / line1 check you must actually
+send that field. Stripe skips the check when the field is absent, so the check
+cannot fail and your test passes for the wrong reason.
+
+| Description | Number | PaymentMethod | Behavior |
+|---|---|---|---|
+| Always blocked | 4100000000000019 | `pm_card_radarBlock` | Risk level "highest"; Radar always blocks |
+| Highest risk | 4000000000004954 | `pm_card_riskLevelHighest` | Risk "highest"; blocked depending on settings |
+| Elevated risk | 4000000000009235 | `pm_card_riskLevelElevated` | Risk "elevated"; may be queued for review |
+| High fraud dispute score | 4000008400000407 | `pm_card_highFraudDisputeScore` | May be blocked per settings |
+| High early-fraud-warning score | 4000008400000159 | `pm_card_highEfwScore` | May be blocked per settings |
+| Dynamic risk thresholds | 4000008400001017 | `pm_card_radarDynamicRiskThreshold` | Blocked if Dynamic risk thresholds enabled |
+| Free trial abuse | 4001858821843804 | `pm_card_freeTrialAbuseBlock` | Blocked if free-trial-abuse control enabled |
+| Adaptive 3DS | 4000008405600003 | `pm_card_adaptive3dsChallenge` | Requests 3DS if Adaptive 3DS enabled |
+| CVC check fails | 4000000000000101 | `pm_card_cvcCheckFail` | Requires a CVC in the request |
+| Postal code check fails | 4000000000000036 | `pm_card_avsZipFail` | Requires a postal code in the request |
+| CVC fails + elevated risk | 4000058400307872 | `pm_card_cvcCheckFailElevatedRisk` | Requires a CVC |
+| Postal code fails + elevated risk | 4000058400306072 | `pm_card_avsZipFailElevatedRisk` | Requires a postal code |
+| Line1 check fails | 4000000000000028 | `pm_card_avsLine1Fail` | Succeeds unless a custom Radar rule blocks it |
+| Address checks fail (zip + line1) | 4000000000000010 | `pm_card_avsFail` | May be blocked per settings |
+| Address checks unavailable | 4000000000000044 | `pm_card_avsUnchecked` | Succeeds unless a custom Radar rule blocks it |
+
+Token equivalents drop the `pm_card_` prefix: `tok_radarBlock`,
+`tok_riskLevelHighest`, `tok_cvcCheckFail`, etc.
+
+## Captcha challenge
+
+Stripe may show a captcha on the payment page as a fraud control.
+
+| Description | Number |
+|---|---|
+| Captcha challenge | 4000000000001208 |
+| Captcha challenge | 4000000000003725 |
+
+The charge succeeds if the user answers the captcha correctly.

--- a/skills/stripe-testing/references/cards-success.md
+++ b/skills/stripe-testing/references/cards-success.md
@@ -1,0 +1,171 @@
+# Stripe test values — successful payments
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+
+Prefer the `pm_*` PaymentMethod in API calls and server-side tests. Raw card
+numbers are for interactive entry in a payment form only. For interactive
+entry: any future expiry (**12/34**), any 3-digit CVC (4 digits for Amex).
+
+Cross-border fees are assessed on the *issuer* country, in test mode too — JCB,
+UnionPay and other non-US cards can carry a cross-border fee in your test
+assertions.
+
+## By card brand
+
+| Brand | Number | PaymentMethod | Token | CVC |
+|---|---|---|---|---|
+| Visa | 4242424242424242 | `pm_card_visa` | `tok_visa` | 3 digits |
+| Visa (debit) | 4000056655665556 | `pm_card_visa_debit` | `tok_visa_debit` | 3 digits |
+| Mastercard | 5555555555554444 | `pm_card_mastercard` | `tok_mastercard` | 3 digits |
+| Mastercard (2-series) | 2223003122003222 | — | — | 3 digits |
+| Mastercard (debit) | 5200828282828210 | `pm_card_mastercard_debit` | `tok_mastercard_debit` | 3 digits |
+| Mastercard (prepaid) | 5105105105105100 | `pm_card_mastercard_prepaid` | `tok_mastercard_prepaid` | 3 digits |
+| American Express | 378282246310005 | `pm_card_amex` | `tok_amex` | 4 digits |
+| American Express | 371449635398431 | — | — | 4 digits |
+| Discover | 6011111111111117 | `pm_card_discover` | `tok_discover` | 3 digits |
+| Discover | 6011000990139424 | — | — | 3 digits |
+| Discover (debit) | 6011981111111113 | — | — | 3 digits |
+| Diners Club | 3056930009020004 | `pm_card_diners` | `tok_diners` | 3 digits |
+| Diners Club (14-digit) | 36227206271667 | — | — | 3 digits |
+| BCcard / DinaCard | 6555900000604105 | — | — | 3 digits |
+| JCB | 3566002020360505 | `pm_card_jcb` | `tok_jcb` | 3 digits |
+| UnionPay | 6200000000000005 | `pm_card_unionpay` | `tok_unionpay` | 3 digits |
+| UnionPay (debit) | 6200000000000047 | — | — | 3 digits |
+| UnionPay (19-digit) | 6205500000000000004 | — | — | 3 digits |
+
+### Co-branded cards
+
+Most Cartes Bancaires and eftpos cards are co-branded with Visa or Mastercard.
+
+| Brand / co-brand | Number | PaymentMethod |
+|---|---|---|
+| Cartes Bancaires / Visa | 4000002500001001 | `pm_card_visa_cartesBancaires` |
+| Cartes Bancaires / Mastercard | 5555552500001001 | `pm_card_mastercard_cartesBancaires` |
+| eftpos Australia / Visa | 4000050360000001 | `pm_card_visa_debit_eftposAuCoBranded` |
+| eftpos Australia / Mastercard | 5555050360000080 | `pm_card_mastercard_debit_eftposAuCoBranded` |
+
+Tokens follow the same naming: `tok_visa_cartesBancaires`, etc.
+
+## By country
+
+Success without authentication. **SCA note:** cards in the Europe/Middle East
+block simulate a payment that succeeds *without* 3DS — they do not exercise
+your SCA path. Test authentication separately with `references/3d-secure.md`.
+
+The `pm_*` and `tok_*` values follow a consistent pattern: `pm_card_<cc>` and
+`tok_<cc>` using the lowercase ISO country code (e.g. `pm_card_hu`, `tok_hu`).
+
+### Americas
+
+| Country | Number | PaymentMethod | Brand |
+|---|---|---|---|
+| United States (US) | 4242424242424242 | `pm_card_us` | Visa |
+| Argentina (AR) | 4000000320000021 | `pm_card_ar` | Visa |
+| Brazil (BR) | 4000000760000002 | `pm_card_br` | Visa |
+| Canada (CA) | 4000001240000000 | `pm_card_ca` | Visa |
+| Chile (CL) | 4000001520000001 | `pm_card_cl` | Visa |
+| Colombia (CO) | 4000001700000003 | `pm_card_co` | Visa |
+| Costa Rica (CR) | 4000001880000005 | `pm_card_cr` | Visa |
+| Ecuador (EC) | 4000002180000000 | `pm_card_ec` | Visa |
+| Mexico (MX) | 4000004840008001 | `pm_card_mx` | Visa |
+| Mexico (MX) | 5062210000000009 | — | Carnet |
+| Panama (PA) | 4000005910000000 | `pm_card_pa` | Visa |
+| Paraguay (PY) | 4000006000000066 | `pm_card_py` | Visa |
+| Peru (PE) | 4000006040000068 | `pm_card_pe` | Visa |
+| Uruguay (UY) | 4000008580000003 | `pm_card_uy` | Visa |
+
+### Europe and Middle East
+
+| Country | Number | PaymentMethod | Brand |
+|---|---|---|---|
+| United Arab Emirates (AE) | 4000007840000001 | `pm_card_ae` | Visa |
+| United Arab Emirates (AE) | 5200007840000022 | `pm_card_ae_mastercard` | Mastercard |
+| Austria (AT) | 4000000400000008 | `pm_card_at` | Visa |
+| Belgium (BE) | 4000000560000004 | `pm_card_be` | Visa |
+| Bulgaria (BG) | 4000001000000000 | `pm_card_bg` | Visa |
+| Belarus (BY) | 4000001120000005 | `pm_card_by` | Visa |
+| Croatia (HR) | 4000001910000009 | `pm_card_hr` | Visa |
+| Cyprus (CY) | 4000001960000008 | `pm_card_cy` | Visa |
+| Czech Republic (CZ) | 4000002030000002 | `pm_card_cz` | Visa |
+| Denmark (DK) | 4000002080000001 | `pm_card_dk` | Visa |
+| Estonia (EE) | 4000002330000009 | `pm_card_ee` | Visa |
+| Finland (FI) | 4000002460000001 | `pm_card_fi` | Visa |
+| France (FR) | 4000002500000003 | `pm_card_fr` | Visa |
+| Germany (DE) | 4000002760000016 | `pm_card_de` | Visa |
+| Gibraltar (GI) | 4000002920000005 | `pm_card_gi` | Visa |
+| Greece (GR) | 4000003000000030 | `pm_card_gr` | Visa |
+| **Hungary (HU)** | **4000003480000005** | **`pm_card_hu`** | Visa |
+| Ireland (IE) | 4000003720000005 | `pm_card_ie` | Visa |
+| Italy (IT) | 4000003800000008 | `pm_card_it` | Visa |
+| Latvia (LV) | 4000004280000005 | `pm_card_lv` | Visa |
+| Liechtenstein (LI) | 4000004380000004 | `pm_card_li` | Visa |
+| Lithuania (LT) | 4000004400000000 | `pm_card_lt` | Visa |
+| Luxembourg (LU) | 4000004420000006 | `pm_card_lu` | Visa |
+| Malta (MT) | 4000004700000007 | `pm_card_mt` | Visa |
+| Netherlands (NL) | 4000005280000002 | `pm_card_nl` | Visa |
+| Norway (NO) | 4000005780000007 | `pm_card_no` | Visa |
+| Poland (PL) | 4000006160000005 | `pm_card_pl` | Visa |
+| Portugal (PT) | 4000006200000007 | `pm_card_pt` | Visa |
+| Romania (RO) | 4000006420000001 | `pm_card_ro` | Visa |
+| Saudi Arabia (SA) | 4000006820000007 | — | Visa |
+| Slovenia (SI) | 4000007050000006 | `pm_card_si` | Visa |
+| Slovakia (SK) | 4000007030000001 | `pm_card_sk` | Visa |
+| Spain (ES) | 4000007240000007 | `pm_card_es` | Visa |
+| Sweden (SE) | 4000007520000008 | `pm_card_se` | Visa |
+| Switzerland (CH) | 4000007560000009 | `pm_card_ch` | Visa |
+| United Kingdom (GB) | 4000008260000000 | `pm_card_gb` | Visa |
+| United Kingdom (GB) | 4000058260000005 | `pm_card_gb_debit` | Visa (debit) |
+| United Kingdom (GB) | 5555558265554449 | `pm_card_gb_mastercard` | Mastercard |
+
+### Asia Pacific
+
+| Country | Number | PaymentMethod | Brand |
+|---|---|---|---|
+| Australia (AU) | 4000000360000006 | `pm_card_au` | Visa |
+| China (CN) | 4000001560000002 | `pm_card_cn` | Visa |
+| Hong Kong (HK) | 4000003440000004 | `pm_card_hk` | Visa |
+| India (IN) | 4000003560000008 | `pm_card_in` | Visa |
+| Japan (JP) | 4000003920000003 | `pm_card_jp` | Visa |
+| Japan (JP) | 3530111333300000 | `pm_card_jcb` | JCB |
+| Malaysia (MY) | 4000004580000002 | `pm_card_my` | Visa |
+| New Zealand (NZ) | 4000005540000008 | `pm_card_nz` | Visa |
+| Singapore (SG) | 4000007020000003 | `pm_card_sg` | Visa |
+| Taiwan (TW) | 4000001580000008 | `pm_card_tw` | Visa |
+| Thailand (TH) | 4000007640000003 | `pm_card_th_credit` | Visa (credit) |
+| Thailand (TH) | 4000057640000008 | `pm_card_th_debit` | Visa (debit) |
+
+India subscriptions requiring mandates and pre-debit notifications have their
+own procedure — see Stripe's India recurring payments testing docs.
+
+## Simulate a customer's location by email
+
+For Checkout Sessions, Payment Links and pricing tables, add a `+location_XX`
+suffix (ISO 3166-1 alpha-2) to the local part of an email to simulate a
+customer's country — you then see the currency and payment methods that
+customer would see.
+
+```
+test+location_US@example.com    → simulates a US customer
+test+location_HU@example.com    → simulates a Hungarian customer
+```
+
+Pass it as `customer_email` when creating a Checkout Session, or as the
+`prefilled_email` URL parameter for a Payment Link.
+
+## HSA / FSA cards
+
+| Type | Number | PaymentMethod |
+|---|---|---|
+| Visa FSA | 4000051230000072 | `pm_card_debit_visaFsaProductCode` |
+| Visa HSA | 4000051230000072 | `pm_card_debit_visaHsaProductCode` |
+| Mastercard FSA | 5200828282828897 | `pm_card_mastercard_debit_mastercardFsaProductCode` |
+
+## Send funds straight to the available balance
+
+Normally a successful test payment lands in the *pending* balance. These cards
+bypass it — useful when a test needs a withdrawable balance immediately.
+
+| Description | Number | PaymentMethod |
+|---|---|---|
+| Bypass pending (US charge) | 4000000000000077 | `pm_card_bypassPending` |
+| Bypass pending (international) | 4000003720000278 | `pm_card_bypassPendingInternational` |

--- a/skills/stripe-testing/references/disputes-refunds.md
+++ b/skills/stripe-testing/references/disputes-refunds.md
@@ -1,0 +1,69 @@
+# Stripe test values — disputes, evidence and refunds
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+
+## Disputes
+
+With default account settings the charge succeeds, then is disputed.
+
+| Description | Number | PaymentMethod |
+|---|---|---|
+| Fraudulent | 4000000000000259 | `pm_card_createDispute` |
+| Product not received | 4000000000002685 | `pm_card_createDisputeProductNotReceived` |
+| Inquiry | 4000000000001976 | `pm_card_createDisputeInquiry` |
+| Early fraud warning | 4000000000005423 | `pm_card_createIssuerFraudRecord` |
+| Multiple disputes | 4000000404000079 | `pm_card_createMultipleDisputes` |
+| Visa Compelling Evidence 3.0 | 4000000404000038 | `pm_card_createCe3EligibleDispute` |
+| Visa compliance | 4000008400000779 | `pm_card_createComplianceDispute` |
+| Mastercard compliance | 5105008400000002 | `pm_card_createMastercardComplianceDispute` |
+| Smart Disputes eligible | 4000000001000043 | `pm_card_createAutoRepresentmentEligibleDispute` |
+
+**3DS protection differs by category:** a *fraudulent* dispute is protected
+after 3D Secure authentication; a *product not received* dispute is not. If you
+are testing whether 3DS shifts liability, these two cards give opposite — and
+both correct — outcomes.
+
+Token equivalents: `tok_createDispute`, `tok_createDisputeInquiry`, etc.
+
+## Evidence — forcing a win or a loss
+
+To close a test dispute with a specific outcome, submit one of these literal
+strings as the evidence text:
+
+- via the API: pass it as `evidence[uncategorized_text]` on [dispute update](https://docs.stripe.com/api/disputes/update)
+- via the Dashboard or Connect embedded components: enter it in **Additional
+  information**, then **Submit evidence**
+
+| Evidence value | Effect |
+|---|---|
+| `winning_evidence` | Dispute closes as won; your account is credited the charge amount and related fees |
+| `losing_evidence` | Dispute closes as lost, no credit. For an inquiry, closes it without escalation |
+| `escalate_inquiry_evidence` | Escalates an inquiry to a full chargeback |
+
+## Asynchronous refunds
+
+In live mode refunds are asynchronous: one can look successful and later fail,
+or start `pending` and later succeed. With every *other* test card, refunds
+succeed immediately and never change status afterwards — which is exactly why a
+refund-failure path goes untested unless you use these.
+
+| Description | Number | PaymentMethod | Behavior |
+|---|---|---|---|
+| Async success | 4000000000007726 | `pm_card_pendingRefund` | Refund starts `pending`, later becomes `succeeded` → `refund.updated` event |
+| Async failure | 4000000000005126 | `pm_card_refundFail` | Refund starts `succeeded`, later becomes `failed` → `refund.failed` event |
+
+**Trap:** asserting immediately after calling refund tests the *initial* state,
+not the outcome. Wait for the webhook event (`refund.updated` / `refund.failed`)
+or poll the refund status.
+
+Token equivalents: `tok_pendingRefund`, `tok_refundFail`.
+
+**Cancelling a card refund** is Dashboard-only. Live mode allows it for a short,
+unspecified window; test mode simulates that window as 30 minutes.
+
+## Payout / balance timing
+
+By default a successful test payment lands in the *pending* balance. To get
+funds into the available balance immediately, use the bypass-pending cards in
+`cards-success.md` (`pm_card_bypassPending`,
+`pm_card_bypassPendingInternational`).

--- a/skills/stripe-testing/references/non-card.md
+++ b/skills/stripe-testing/references/non-card.md
@@ -1,0 +1,192 @@
+# Stripe test values — non-card payment methods
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+
+**Coverage is deliberately partial.** SEPA Direct Debit publishes a full set per
+country; this file carries a representative subset (AT, BE, DE, FR, IE, plus the
+naming pattern) covering the scenarios you actually test. For a country not
+listed, fetch the live page — the *scenarios* are identical everywhere, only the
+IBANs differ.
+
+Use test API keys for all of these, same as for cards.
+
+## SEPA Direct Debit
+
+Procedure: create a test PaymentMethod with a test IBAN, then use it in a
+`confirmSepaDebitPayment` request.
+
+Every country exposes the same scenario set, with tokens named
+`pm_sepaDebit_<scenario>_<cc>`:
+
+| Scenario | Token suffix | Behavior |
+|---|---|---|
+| Success | `success` | `processing` → `succeeded` |
+| Delayed success | `successDelayed` | `processing` → `succeeded` after ≥3 minutes |
+| Failure | `failed` | `processing` → `requires_payment_method` |
+| Delayed failure | `failedDelayed` | `processing` → `requires_payment_method` after ≥3 min |
+| Disputed | `disputed` | `processing` → `succeeded`, dispute created immediately |
+| Weekly volume limit | `exceedsWeeklyVolumeLimit` | Fails with `charge_exceeds_source_limit` |
+| Weekly transaction limit | `exceedsWeeklyTransactionLimit` | Fails with `charge_exceeds_weekly_limit` |
+| Insufficient funds | `insufficientFunds` | Fails with `insufficient_funds` |
+| Bank doesn't support SEPA DD | (no token) | PaymentMethod creation fails, `sepa_debit_bank_not_supported` |
+| Account can't be debited | (no token) | PaymentMethod creation fails, `sepa_debit_debits_not_supported` |
+
+The last two apply to SetupIntents and PaymentIntents that include inline IBAN
+data, and fail at *creation* time rather than at charge time.
+
+**The delayed variants are the ones worth wiring into a test.** A SEPA
+integration that only tests the instant path never exercises the `processing`
+state your UI has to render.
+
+### Austria (AT)
+
+| IBAN | Token |
+|---|---|
+| AT611904300234573201 | `pm_sepaDebit_success_at` |
+| AT321904300235473204 | `pm_sepaDebit_successDelayed_at` |
+| AT861904300235473202 | `pm_sepaDebit_failed_at` |
+| AT051904300235473205 | `pm_sepaDebit_failedDelayed_at` |
+| AT591904300235473203 | `pm_sepaDebit_disputed_at` |
+| AT981904300000343434 | `pm_sepaDebit_exceedsWeeklyVolumeLimit_at` |
+| AT601904300000121212 | `pm_sepaDebit_exceedsWeeklyTransactionLimit_at` |
+| AT981904300002222227 | `pm_sepaDebit_insufficientFunds_at` |
+| AT271904300000055555 | (bank not supported) |
+| AT511904300000066666 | (debits not supported) |
+
+### Belgium (BE)
+
+| IBAN | Token |
+|---|---|
+| BE62510007547061 | `pm_sepaDebit_success_be` |
+| BE78510007547064 | `pm_sepaDebit_successDelayed_be` |
+| BE68539007547034 | `pm_sepaDebit_failed_be` |
+| BE51510007547065 | `pm_sepaDebit_failedDelayed_be` |
+| BE08510007547063 | `pm_sepaDebit_disputed_be` |
+| BE90510000343434 | `pm_sepaDebit_exceedsWeeklyVolumeLimit_be` |
+| BE52510000121212 | `pm_sepaDebit_exceedsWeeklyTransactionLimit_be` |
+| BE90510002222227 | `pm_sepaDebit_insufficientFunds_be` |
+| BE19510000055555 | (bank not supported) |
+| BE43510000066666 | (debits not supported) |
+
+### Germany (DE)
+
+| IBAN | Token |
+|---|---|
+| DE89370400440532013000 | `pm_sepaDebit_success_de` |
+| DE08370400440532013003 | `pm_sepaDebit_successDelayed_de` |
+| DE62370400440532013001 | `pm_sepaDebit_failed_de` |
+| DE78370400440532013004 | `pm_sepaDebit_failedDelayed_de` |
+| DE35370400440532013002 | `pm_sepaDebit_disputed_de` |
+| DE65370400440000343434 | `pm_sepaDebit_exceedsWeeklyVolumeLimit_de` |
+| DE27370400440000121212 | `pm_sepaDebit_exceedsWeeklyTransactionLimit_de` |
+| DE65370400440002222227 | `pm_sepaDebit_insufficientFunds_de` |
+| DE91370400440000055555 | (bank not supported) |
+| DE18370400440000066666 | (debits not supported) |
+
+### France (FR)
+
+| IBAN | Token |
+|---|---|
+| FR1420041010050500013M02606 | `pm_sepaDebit_success_fr` |
+| FR3020041010050500013M02609 | `pm_sepaDebit_successDelayed_fr` |
+| FR8420041010050500013M02607 | `pm_sepaDebit_failed_fr` |
+| FR7920041010050500013M02600 | `pm_sepaDebit_failedDelayed_fr` |
+| FR5720041010050500013M02608 | `pm_sepaDebit_disputed_fr` |
+| FR9720041010050000000343434 | `pm_sepaDebit_exceedsWeeklyVolumeLimit_fr` |
+| FR5920041010050000000121212 | `pm_sepaDebit_exceedsWeeklyTransactionLimit_fr` |
+| FR9720041010050000002222227 | `pm_sepaDebit_insufficientFunds_fr` |
+| FR2620041010050000000055555 | (bank not supported) |
+| FR5020041010050000000066666 | (debits not supported) |
+
+### Ireland (IE)
+
+| IBAN | Token |
+|---|---|
+| IE29AIBK93115212345678 | `pm_sepaDebit_success_ie` |
+| IE24AIBK93115212345671 | `pm_sepaDebit_successDelayed_ie` |
+| IE02AIBK93115212345679 | `pm_sepaDebit_failed_ie` |
+| IE94AIBK93115212345672 | `pm_sepaDebit_failedDelayed_ie` |
+| IE51AIBK93115212345670 | `pm_sepaDebit_disputed_ie` |
+| IE10AIBK93115200343434 | `pm_sepaDebit_exceedsWeeklyVolumeLimit_ie` |
+| IE69AIBK93115200121212 | `pm_sepaDebit_exceedsWeeklyTransactionLimit_ie` |
+| IE10AIBK93115202222227 | `pm_sepaDebit_insufficientFunds_ie` |
+| IE36AIBK93115200055555 | (bank not supported) |
+| IE60AIBK93115200066666 | (debits not supported) |
+
+### Other countries
+
+Stripe also publishes SEPA test IBANs for HR, EE, FI, GI, LI, LT, LU, MT, NL,
+NO, PL, PT, RO, SI, SK, ES, SE, CH and GB, following the identical scenario and
+token-naming pattern. Fetch [docs.stripe.com/testing](https://docs.stripe.com/testing)
+when you need one.
+
+## ACH Direct Debit (US)
+
+### Test account numbers
+
+All use routing number `110000000`.
+
+| Account number | Token | Behavior |
+|---|---|---|
+| `000123456789` | `pm_usBankAccount_success` | Payment succeeds |
+| `000111111113` | `pm_usBankAccount_accountClosed` | Fails — account closed |
+| `000000004954` | `pm_usBankAccount_riskLevelHighest` | Blocked by Radar (high fraud risk) |
+| `000111111116` | `pm_usBankAccount_noAccount` | Fails — no account found |
+| `000222222227` | `pm_usBankAccount_insufficientFunds` | Fails — insufficient funds |
+| `000333333335` | `pm_usBankAccount_debitNotAuthorized` | Fails — debits not authorized |
+| `000444444440` | `pm_usBankAccount_invalidCurrency` | Fails — invalid currency |
+| `000666666661` | `pm_usBankAccount_failMicrodeposits` | Fails to send microdeposits |
+| `000555555559` | `pm_usBankAccount_dispute` | Triggers a dispute |
+| `000000000009` | `pm_usBankAccount_processing` | Stays in `processing` indefinitely — use to test PaymentIntent cancellation |
+| `000777777771` | `pm_usBankAccount_weeklyLimitExceeded` | Fails — weekly volume limit |
+| `000888888885` | — | Fails — deactivated tokenized account number |
+
+Accounts that auto-succeed or auto-fail must be **verified first** using the
+microdeposit values below.
+
+### Microdeposit amounts and descriptor codes
+
+Use either the two amounts *or* the 0.01 descriptor code.
+
+| Microdeposit values | Descriptor code | Scenario |
+|---|---|---|
+| `32` and `45` | SM11AA | Verifies the account |
+| `10` and `11` | SM33CC | Exceeds allowed verification attempts |
+| `40` and `41` | SM44DD | Microdeposit timeout |
+
+### Transaction emails in a sandbox
+
+Mandate-confirmation and microdeposit-verification emails only send when the
+address carries a `+test_email` suffix: `{username}+test_email@{domain}` — e.g.
+`info+test_email@example.com`. Without the suffix, no email is sent. The Stripe
+account must be set up before these emails trigger.
+
+### Settlement timing
+
+Test ACH transactions settle **instantly** into the available balance. Live mode
+takes multiple days — so any test asserting on settlement timing is testing
+sandbox behavior, not production behavior.
+
+Instant verification via Financial Connections has its own test accounts — see
+Stripe's Financial Connections testing docs.
+
+## Terminal / in-person payments
+
+For a payment involving a PIN:
+
+| Description | Number | PaymentMethod |
+|---|---|---|
+| Offline PIN | 4001007020000002 | `offline_pin_cvm` |
+| Offline PIN retry (SCA) | 4000008260000075 | `offline_pin_sca_retry` |
+| Online PIN | 4001000360000005 | `online_pin_cvm` |
+| Online PIN retry (SCA) | 4000002760000008 | `online_pin_sca_retry` |
+
+The resulting charge carries
+`payment_method_details.card_present.receipt.cardholder_verification_method` set
+to `offline_pin` / `online_pin`. The retry cards simulate a contactless charge
+failing and the reader then prompting for card insertion and a PIN.
+
+Terminal has a much broader testing surface (simulated readers, physical test
+cards) documented separately at
+[docs.stripe.com/terminal/references/testing](https://docs.stripe.com/terminal/references/testing) —
+not duplicated here.

--- a/skills/stripe-testing/references/workflow.md
+++ b/skills/stripe-testing/references/workflow.md
@@ -1,0 +1,68 @@
+# Stripe testing — sandboxes, webhooks and limits
+
+Captured from [docs.stripe.com/testing](https://docs.stripe.com/testing) on 2026-08-07.
+
+## Sandboxes
+
+A sandbox is an isolated test environment inside your account: test transactions
+that don't move funds and don't touch the live integration. Reach them through
+the account picker in the [Dashboard](https://dashboard.stripe.com/sandboxes).
+
+## Test API keys
+
+Use test keys for every call in a test, whether serving a payment form
+interactively or running automated tests. Test keys cannot process live
+payments; live keys must never appear in source or config committed to version
+control — environment variables or a secrets vault only. See Stripe's
+[key best practices](https://docs.stripe.com/keys-best-practices).
+
+## Interactive vs. code
+
+| Context | Use |
+|---|---|
+| Payment form, Dashboard, manual click-through | Raw card number, e.g. `4242 4242 4242 4242`, expiry **12/34**, any CVC |
+| API calls, server-side code, automated tests | A PaymentMethod, e.g. `pm_card_visa` |
+
+Raw card numbers in server-side code risk putting that code path outside PCI
+compliance once it goes live, even if it started as "just a test". A test
+PaymentMethod is not attached to a Customer by default.
+
+## Testing webhooks / event destinations
+
+Two approaches:
+
+1. **Drive real events** — perform actions in the sandbox that legitimately
+   produce the event (e.g. charge a success card to get `charge.succeeded`).
+   Slower, but exercises the real payload.
+2. **Trigger events directly** with the [Stripe CLI](https://docs.stripe.com/webhooks#test-webhook)
+   (`stripe trigger <event>`) or the Stripe VS Code extension. Fast and precise,
+   but the payload is synthetic.
+
+Use approach 1 for the integration test that must be right, approach 2 for
+breadth across event types.
+
+**Always test double delivery.** Stripe delivers the same event more than once
+in production; a test firing each event exactly once cannot catch a
+double-charge. Deliver the same event ID twice and assert a single effect. See
+the data-integrity rule for the idempotency patterns (upsert over increment, key
+on the event ID).
+
+## Rate limits
+
+Test-mode rate limits are **stricter than live mode**. If you start seeing `429`
+responses, slow the requests down.
+
+Do not load-test through the Stripe API in a sandbox: the stricter limiter
+produces failures you'd never see in production, so the results are misleading.
+Stripe documents a separate approach under
+[load testing](https://docs.stripe.com/rate-limits#load-testing).
+
+## Related rules in this toolkit
+
+- `rules/stripe-testing.md` — the non-negotiables (loads automatically on
+  payment-related files)
+- `rules/payments.md` — PSP onboarding, provider abstraction, SDK pinning,
+  currency decimals
+- `rules/data-integrity.md` — idempotency and race-condition patterns that
+  webhook handling depends on
+- `rules/testing.md` — general test-quality policy


### PR DESCRIPTION
## Summary

Adds a `stripe-testing` skill + rule pair so Stripe integration work in any project follows documented test values and non-negotiables, instead of guessing card numbers or improvising decline testing.

- **`rules/stripe-testing.md`** — contextual rule, loads on `**/*stripe*`, `**/*payment*`, `**/*billing*`, `**/*checkout*`, `**/*subscription*`. Covers: never real cards in test mode, no raw PANs in server code (use `PaymentMethod` IDs), test/live key separation, decline assertions on `code`/`decline_code` not message text, webhook idempotency proof, and that Stripe's test-mode rate limits are *stricter* than live (so it isn't a load-test target).
- **`skills/stripe-testing/`** — reference tables backing the rule: test cards (success + decline), 3D Secure/SCA cards, disputes & refund evidence values, non-card methods (SEPA/ACH), and a workflow doc for webhook triggering.
- **`bin/git-verify.sh`** — read-only git-status snapshot (branch, uncommitted tracked changes, recent commits, ahead/behind vs. upstream) in one call, useful for background-agent runs where losing unpushed work is the risk being guarded against.
- **README.md** — documents the new rule and skill in their respective reference tables.
- **`.gitignore`** — adds `skills/.system/`. That directory holds Codex-managed skills that get written into this working directory locally; they're maintained by Codex itself, not part of this toolkit, and shouldn't be tracked here.

## Test plan

- [x] Pre-commit gitleaks hook ran clean on this commit
- [x] Documentation/skill content only — no application code to unit test
- [x] Verified `skills/.system/` no longer shows as untracked after the `.gitignore` change
