### PR TITLE
feat(release-pr): add develop → master release PR skill

### DIFF
--- a/skills/release-pr/SKILL.md
+++ b/skills/release-pr/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: release-pr
+description: Create the develop → master release PR — inspect what changed since the last tag, decide the semver bump, apply the release:major/minor/patch label so the tag is generated correctly, and write the release body. Use for "release to master", "promote develop", "make a release PR", "cut a release", "new version tag".
+argument-hint: [major|minor|patch]
+user-invocable: true
+---
+
+# Release PR — develop → master
+
+Promotes the accumulated `develop` batch to `master`. Merging the PR is what
+creates the version tag and triggers the staging deploy, so the **label is
+load-bearing**: `semver-tag.yml` reads the merged PR's `release:*` label and
+computes the new tag from it. A wrong label ships a wrong version number; a
+missing label fails the merge.
+
+**You do not create the tag.** Do not run `git tag`. The workflow does it.
+
+## Step 1 — Collect the facts
+
+```bash
+bash ~/.claude/skills/release-pr/collect.sh --repo OWNER/NAME
+```
+
+Omit `--repo` to let it resolve via `gh repo view`. Read-only: it fetches and
+inspects, never writes a ref. Output sections:
+
+| Section | What it decides |
+|---|---|
+| CURRENT VERSION | the three candidate tags — you pick one |
+| SIZE | the "N merged PRs, N commits, N files, +N/−N" opening line |
+| BEHIND CHECK | **stop condition** — see below |
+| MERGED PRs IN THIS BATCH | the list you write the body from |
+| SEMVER SIGNALS | migrations, lockfiles, env vars, API surface |
+
+**BEHIND CHECK is a gate.** Merge commits from past releases are expected.
+A *non-merge* commit on master only means a hotfix landed directly on master
+and is not in develop — back-merge it into develop before releasing, or the
+release silently ships around it.
+
+## Step 2 — Decide the bump
+
+Answer one question: **could a user do something after this release they could
+not do before?**
+
+| Bump | When | Real example |
+|---|---|---|
+| `major` | breaking change consumers must react to — removed/renamed route or response field, a migration dropping data still in use, a config rename with no fallback | (none yet in this repo) |
+| `minor` | new capability that did not exist in the previous tag | v1.9.0 — registration kill-switch, unified seen-tracking |
+| `patch` | fixes, refactors, docs, dependency bumps, tests. No new capability | v1.7.1 — backups produced archives that could not be restored; "fixes a path that was already supposed to work" |
+
+Mixed batch → the highest bump present wins. A batch with one new feature and
+twelve fixes is `minor`.
+
+If the argument (`$ARGUMENTS`) names a bump, use it. Otherwise decide from the
+signals and **state the reasoning in the PR body** — every past release does.
+
+## Step 3 — Write the body
+
+Write to `/tmp/<project>-pr-body-release-<version>.md` with the Write tool
+(never a heredoc), then pass it as `--body-file`.
+
+Structure, consistent across every release since v1.5.0:
+
+```markdown
+## Release develop → master (vOLD → vNEW)
+
+Promotes the current `develop` batch (N merged PRs, N commits, N files,
++N/−N) to `master`, tagging a semver release and deploying to **staging**.
+
+`release:<bump>` — <one paragraph justifying the bump, naming what is new or
+what class of thing is fixed, and explicitly noting what is NOT affected:
+"no breaking API change and no schema change".>
+
+### <Thematic heading, not a PR number> (#issue, PR #n)
+
+<What was broken or missing, why it mattered, how it was closed. Prose, not
+a changelog. Group related PRs under one heading.>
+
+### Also in this batch
+
+- **<Short label>** (#n) — one or two lines each for the smaller items.
+
+## Operator note          ← only if a human must DO something
+## Migration note         ← only if migrations changed
+## Deploy note            ← always
+
+<!-- AGENT-REVIEW:START -->
+...six checklist items, every box [x]...
+<!-- AGENT-REVIEW:END -->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Headings describe **the problem solved**, not the PR. Past releases use
+"The empty string was a config hole", "The restore path did not work",
+"Production health check pointed at a path that never existed".
+
+### The three notes
+
+- **Operator note** — anything a human must do around the deploy: renamed env
+  vars (with an old→new table), a new variable to set, a feature that ships
+  *off* and needs turning on. Include the restart caveat: use `stop.sh`/
+  `start.sh`, since a plain `docker compose restart` leaves `pam_api` untouched
+  behind its `depends_on` health gate, so a new env value never reaches the
+  process.
+- **Migration note** — one bullet per migration: what it does, whether it is
+  additive or destructive, whether it is idempotent. Call out any drop
+  explicitly and say why it is safe (e.g. expand/contract split across two
+  revisions so no intermediate commit is inconsistent).
+- **Deploy note** — always. State the tag and that merging triggers
+  `deploy-staging`. If a lockfile changed, say **"this is a rebuild, not a
+  plain restart."**
+
+### AGENT-REVIEW section
+
+Mandatory when the PR carries `agent-authored` (auto-applied). The
+`agent-pr-checklist` gate fails if the section is missing or any box is
+unticked. Copy the six items from `.github/PULL_REQUEST_TEMPLATE.md` and tick
+each with a **specific justification for this batch** — not a bare `[x]`:
+
+```
+- [x] No destructive ops added without a second barrier — `20260812002` drops
+      `persons.waves_last_viewed_at`, deliberately split into its own revision
+      so it runs only after the data moved to `match_actions.seen_at`
+```
+
+If an item genuinely does not apply, say why it does not apply. Never tick a
+box you have not checked.
+
+## Step 4 — Create the PR
+
+Apply the label **at creation**, so `semver-check` sees exactly one:
+
+```bash
+gh pr create --repo OWNER/NAME --base master --head develop \
+  --label "release:minor" \
+  --title "release: v1.9.0 — registration kill-switch (#2480), unified seen-tracking (#2466), bare-domain vhosts (#2369)" \
+  --body-file /tmp/pam-pr-body-release-190.md
+```
+
+Title format: `release: vX.Y.Z — <2-3 headline items with issue numbers>`.
+
+## Step 5 — Verify the gates
+
+```bash
+gh pr view <PR> --repo OWNER/NAME --json labels,statusCheckRollup \
+  -q '{labels: [.labels[].name], checks: [.statusCheckRollup[] | {name, status, conclusion}]}'
+```
+
+Expect `Validate release label`, `agent-pr-checklist`, `agent-pr-label`,
+`vitest`, `tsc --noEmit`, `dependency-audit` to pass. `Auto-merge minor/patch`
+and `Playwright E2E` skip on release PRs — that is normal, not a failure.
+
+To wait for them without polling by hand:
+
+```bash
+prev=""
+while true; do
+  s=$(gh pr checks <PR> --repo OWNER/NAME --json name,bucket 2>/dev/null) || { sleep 30; continue; }
+  [ -z "$s" ] && { sleep 30; continue; }
+  cur=$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' <<<"$s" | sort -u)
+  comm -13 <(echo "$prev") <(echo "$cur")
+  prev=$cur
+  jq -e 'all(.bucket!="pending")' <<<"$s" >/dev/null 2>&1 && { echo "ALL CHECKS COMPLETE"; break; }
+  sleep 30
+done
+```
+
+## Step 6 — Stop
+
+**Do not merge.** No server-side protection on the free tier makes merging to
+`master` the user's call. Report the PR URL, the bump and its reasoning, the
+green checks, and any operator action needed before the deploy.
+
+After the user merges, the tag appears automatically:
+
+```bash
+git fetch origin --tags --quiet && git tag --sort=-v:refname | head -3
+git show v1.9.0 --no-patch --format='%s'
+```
+
+The tag is annotated, tagged by `github-actions[bot]`, with message
+`Release vX.Y.Z (PR #N: <title>)`.
+
+## Gotchas
+
+- **The label must be present at merge, not just at creation.** `semver-tag.yml`
+  re-reads the labels of the merged PR. Removing it after CI goes green fails
+  the tag job with "Expected exactly one release:* label".
+- **Exactly one `release:*` label.** Two labels fail `semver-check`; the tag job
+  fails the same way as a defence in depth.
+- **`--label` at creation beats `gh pr edit` after.** `semver-check` runs on
+  `opened`, so creating unlabelled fires one red check before the label lands.
+- **An unlabelled PR to master fails the tag job after the merge has landed.**
+  PR #2205 (ad-hoc hotfix, pre-convention) merged fine, then `Semver Tag` ran
+  and **failed** — `Expected exactly one release:* label, found 0`. The commit
+  is on master, untagged, and the failure is only visible in the Actions tab.
+  The `skip` branch covers only a *direct push* with no PR behind it, never an
+  unlabelled PR. Label before merging, always.
+- **Merge commits on master are not "master is ahead".** Every past release
+  leaves one. Only non-merge commits there are a problem.
+- **The tag is computed from the latest existing tag**, not from the PR title.
+  A title saying v1.9.0 while the label says `patch` produces v1.8.1 and a
+  title that lies. Recompute the title from the label.
+- **`git tag` by hand breaks the next release.** The workflow reads the highest
+  existing tag; a stray tag shifts every future version.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Validate release label` fails: "no release label" | created without `--label` | `gh pr edit <PR> --add-label release:minor` |
+| `agent-pr-checklist` fails | AGENT-REVIEW section missing, or a box left `[ ]` | restore from `.github/PULL_REQUEST_TEMPLATE.md`, tick every box with a justification |
+| `dependency-audit` fails | a time-boxed exception expired | check `docs/governance/audit-exceptions.yml`; take the fix if past cooldown, otherwise re-date to the cooldown end — never override the cooldown for a security label |
+| No tag after merge | label removed before merge, or direct push | check the `Semver Tag` run; re-tagging by hand needs care since it becomes the base for the next release |
+| `collect.sh` shows a non-merge commit on master | hotfix landed directly on master | back-merge master into develop before releasing |

--- a/skills/release-pr/collect.sh
+++ b/skills/release-pr/collect.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Collect everything needed to write a develop -> master release PR body.
+#
+# Emits a single report to stdout: current version, what the batch contains,
+# and the facts that decide the semver bump and the operator/migration notes.
+# Read-only: fetches and inspects, never writes a ref.
+#
+# Usage: collect.sh [--repo OWNER/NAME] [--base master] [--head develop]
+
+set -uo pipefail
+
+REPO=""
+BASE="master"
+HEAD="develop"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --base) BASE="$2"; shift 2 ;;
+    --head) HEAD="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) || {
+    echo "Cannot determine repo. Pass --repo OWNER/NAME." >&2; exit 1; }
+fi
+
+# git may warn about sandbox-masked .gitmodules; harmless, keep stderr quiet.
+git fetch origin --tags --quiet 2>/dev/null
+
+RANGE_AHEAD="origin/$BASE..origin/$HEAD"
+RANGE_DIFF="origin/$BASE...origin/$HEAD"
+
+echo "=== REPO ==="
+echo "$REPO  ($HEAD -> $BASE)"
+
+echo
+echo "=== CURRENT VERSION ==="
+LATEST=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+[ -z "$LATEST" ] && LATEST="v0.0.0"
+echo "latest tag: $LATEST"
+V=${LATEST#v}
+MAJOR=${V%%.*}; REST=${V#*.}; MINOR=${REST%%.*}; PATCH=${REST#*.}
+echo "next: major=v$((MAJOR+1)).0.0  minor=v$MAJOR.$((MINOR+1)).0  patch=v$MAJOR.$MINOR.$((PATCH+1))"
+
+echo
+echo "=== SIZE ==="
+PRS=$(git rev-list --count --first-parent "$RANGE_AHEAD")
+COMMITS=$(git rev-list --count "$RANGE_AHEAD")
+echo "merges (PRs): $PRS"
+echo "commits: $COMMITS"
+git diff --shortstat "$RANGE_DIFF"
+
+echo
+echo "=== BEHIND CHECK (commits on $BASE not in $HEAD) ==="
+BEHIND=$(git rev-list --count "origin/$HEAD..origin/$BASE")
+echo "count: $BEHIND  (merge commits from past releases are expected and harmless)"
+# Only NON-merge commits matter: they are work that exists on $BASE and nowhere
+# else, and a release would silently carry them along unreviewed.
+NONMERGE=$(git rev-list --no-merges "origin/$HEAD..origin/$BASE")
+if [ -n "$NONMERGE" ]; then
+  echo
+  echo "!! non-merge commits present on $BASE only:"
+  git log --oneline --no-merges "origin/$HEAD..origin/$BASE"
+  echo "   Each is either a hotfix landed directly on $BASE (should be back-merged"
+  echo "   into $HEAD first) or pre-dates the release convention. Check before releasing."
+else
+  echo "OK: no non-merge commits -- $BASE carries nothing $HEAD lacks."
+fi
+
+echo
+echo "=== MERGED PRs IN THIS BATCH ==="
+LAST_RELEASE_AT=$(gh pr list --repo "$REPO" --base "$BASE" --state merged --limit 1 \
+  --json mergedAt -q '.[0].mergedAt' 2>/dev/null)
+if [ -n "$LAST_RELEASE_AT" ] && [ "$LAST_RELEASE_AT" != "null" ]; then
+  echo "(merged into $HEAD after the last release at $LAST_RELEASE_AT)"
+  gh pr list --repo "$REPO" --state merged --base "$HEAD" --limit 100 \
+    --json number,title,mergedAt \
+    -q ".[] | select(.mergedAt > \"$LAST_RELEASE_AT\") | \"#\(.number) \(.title)\""
+else
+  echo "(no previous release PR found; listing recent merges to $HEAD)"
+  gh pr list --repo "$REPO" --state merged --base "$HEAD" --limit 20 \
+    --json number,title -q '.[] | "#\(.number) \(.title)"'
+fi
+
+echo
+echo "=== SEMVER SIGNALS ==="
+echo "-- new migrations (additive vs destructive matters) --"
+git diff --name-status "$RANGE_DIFF" \
+  | grep -iE 'alembic/versions/|migrations/' || echo "(none)"
+
+echo
+echo "-- destructive migration ops (drop/delete) --"
+MIGRATIONS=$(git diff --name-only "$RANGE_DIFF" | grep -iE 'alembic/versions/|migrations/')
+if [ -n "$MIGRATIONS" ]; then
+  # shellcheck disable=SC2086
+  git diff "$RANGE_DIFF" -- $MIGRATIONS \
+    | grep -iE '^\+.*(drop_column|drop_table|drop_constraint|DROP |DELETE FROM)' \
+    || echo "(none)"
+else
+  echo "(no migrations)"
+fi
+
+echo
+echo "-- lockfiles (changed => rebuild, not a plain restart) --"
+git diff --name-status "$RANGE_DIFF" -- \
+  '*uv.lock' '*package-lock.json' '*pyproject.toml' '*package.json' || true
+
+echo
+echo "-- new/changed env vars (operator note candidates) --"
+git diff "$RANGE_DIFF" -- '*.env.example' \
+  | grep -E '^[+-][A-Z_]+=' | sort -u || echo "(none)"
+
+echo
+echo "-- API surface (route decorators added/removed) --"
+git diff "$RANGE_DIFF" -- '*.py' \
+  | grep -E '^[+-]@(router|app)\.(get|post|put|patch|delete)' | sort -u || echo "(none)"
+
+echo
+echo "=== BUMP GUIDANCE ==="
+cat <<'GUIDE'
+major -> a breaking change consumers must react to: removed/renamed API route
+         or response field, a migration that drops data still in use, a config
+         key rename with no fallback.
+minor -> new capability that did not exist in the previous tag (new endpoint,
+         new feature flag, new user-visible behaviour). Additive migrations.
+patch -> fixes, refactors, docs, dependency bumps, tests. No new capability.
+
+When in doubt between minor and patch, ask: could a user do something after
+this release they could not do before? Yes -> minor.
+GUIDE


### PR DESCRIPTION
Codifies the develop → master release procedure as a skill: inspect what
changed since the last tag, decide the semver bump, apply the `release:*`
label so `semver-tag` generates the right version, and write the release body.

The label is load-bearing — `semver-tag.yml` reads the merged PR's `release:*`
label and computes the tag from the highest existing tag. The skill never runs
`git tag`; the workflow owns that.

## Contents

- **`collect.sh`** — read-only report: current tag plus the three candidate
  versions, batch size for the opening line, the PR list since the last
  release, and the signals that drive the bump and the notes (migrations,
  destructive ops, lockfiles, env vars, API routes). Shellcheck clean.
- **`SKILL.md`** — the procedure, with the body structure every release since
  v1.5.0 shares.

## Findings that changed the guidance

Derived from the nine PAM releases since the convention landed (#1750 onward),
each checked against workflow **run history** rather than inferred from the
YAML — the first two contradicted my initial reading of the workflow:

- **An unlabelled PR to master makes `semver-tag` FAIL**, after the merge has
  already landed: `Expected exactly one release:* label, found 0`, leaving an
  untagged commit on master and the failure visible only in the Actions tab
  (PR #2205, 2026-07-01). The `skip` branch covers only a *direct push* with no
  PR behind it — not an unlabelled PR.
- **Passing `--label` at creation avoids a red check.** `semver-check` runs on
  `opened`, so labelling afterwards fires one failure first: v1.8.0 shows
  failure-then-success, v1.9.0 (labelled at creation) shows no red run.
- **Only non-merge commits on the base branch signal a problem.** Every past
  release leaves a merge commit there; an early draft flagged all 10 as
  suspicious. Filtering to non-merge commits surfaces exactly the one real
  anomaly — the pre-convention ad-hoc hotfix.

The `major` row in the bump table has no example: it has not occurred in this
repo, and inventing one would be guessing.

## Verification

- `collect.sh` run end-to-end against the live PAM repo via its documented
  path (`~/.claude/skills/release-pr/collect.sh`), exit 0
- `shellcheck` clean
- Procedure itself exercised end-to-end this session: PR #2496 → merged →
  `v1.9.0` tagged by `github-actions[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
