### PR TITLE
Scope design rules with paths:, exempt existing codebases

### DIFF
--- a/bin/project-test.sh
+++ b/bin/project-test.sh
@@ -41,9 +41,16 @@ if [[ "$has_path_arg" == false ]]; then
   echo "[project-test.sh] WARNING: No test path specified — running full suite. Use a specific path for faster runs." >&2
 fi
 
-# Auto-detect venv and use its pytest directly (no activation needed)
+# Auto-detect venv and use its pytest directly (no activation needed).
+# The list is ordered nearest-first and covers CWD at the project root as well
+# as one level below it. `../backend/*` is the case that is easy to miss: from
+# a sibling of the venv's directory (e.g. cwd=frontend/ with the venv in
+# backend/), neither `.venv` nor `../.venv` matches. Without it the loop falls
+# through to the system pytest, which usually still runs — silently, against
+# the wrong interpreter and dependency set.
+# Keep this list in sync with the fallback loop below and with venv-run.sh.
 PYTEST_CMD=""
-for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv; do
+for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv ../backend/.venv ../backend/venv; do
   if [[ -f "$venv_dir/bin/pytest" ]]; then
     PYTEST_CMD="$venv_dir/bin/pytest"
     echo "[project-test.sh] Using pytest from $venv_dir" >&2
@@ -51,9 +58,9 @@ for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv; do
   fi
 done
 
-# Fallback: venv python with -m pytest
+# Fallback: venv python with -m pytest (same search list as above)
 if [[ -z "$PYTEST_CMD" ]]; then
-  for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv; do
+  for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv ../backend/.venv ../backend/venv; do
     if [[ -f "$venv_dir/bin/python" ]]; then
       echo "[project-test.sh] Using python -m pytest from $venv_dir" >&2
       exec "$venv_dir/bin/python" -m pytest "$@"

--- a/bin/venv-run.sh
+++ b/bin/venv-run.sh
@@ -24,8 +24,14 @@ fi
 CMD="$1"
 shift
 
-# Auto-detect venv and use its binary
-for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv; do
+# Auto-detect venv and use its binary.
+# The list is ordered nearest-first and covers CWD at the project root as well
+# as one level below it. `../backend/*` is the case that is easy to miss: from
+# a sibling of the venv's directory (e.g. cwd=frontend/ with the venv in
+# backend/), neither `.venv` nor `../.venv` matches. Without it the loop falls
+# through to the system interpreter, which usually still runs — silently,
+# against the wrong Python and dependency set.
+for venv_dir in .venv venv backend/.venv backend/venv ../.venv ../venv ../backend/.venv ../backend/venv; do
   if [[ -f "$venv_dir/bin/$CMD" ]]; then
     echo "[venv-run.sh] Using $CMD from $venv_dir" >&2
     exec "$venv_dir/bin/$CMD" "$@"

--- a/rules/api-design.md
+++ b/rules/api-design.md
@@ -1,8 +1,17 @@
 ---
 description: API design standards for HTTP APIs
+paths: "**/api/**, **/routes/**, **/handlers/**, **/endpoints/**, **/controllers/**, **/schemas/**, **/*router*, **/openapi*"
 ---
 
 # API Design
+
+> **Existing codebases: match what is already there.** These are the defaults
+> for a NEW API. Where a project already has an established convention — error
+> format, pagination style, status-code usage — that convention wins, and this
+> rule is not a licence to change it in passing. Applying a standard from here
+> to one endpoint of an API that does it differently creates two conventions
+> where there was one. Verify against the codebase first; propose a migration
+> as separate work if the gap matters.
 
 - Use standard HTTP status codes — don't invent custom ones:
 

--- a/rules/database-concurrency.md
+++ b/rules/database-concurrency.md
@@ -1,3 +1,8 @@
+---
+description: Sync vs async DB-access lanes and connection-pool hardening
+paths: "**/database/**, **/db/**, **/models/**, **/repositories/**, **/*session*, **/*engine*, **/api/**, **/routes/**, **/endpoints/**, **/worker*/**, **/tasks/**"
+---
+
 # Database Concurrency
 
 Pick one DB-access lane and stay in it. Mixing sync and async is the trap, not

--- a/rules/dependency-versioning.md
+++ b/rules/dependency-versioning.md
@@ -1,5 +1,6 @@
 ---
 description: How to choose, pin, and age dependency versions safely across any ecosystem
+paths: "**/package.json, **/package-lock.json, **/pyproject.toml, **/uv.lock, **/requirements*.txt, **/poetry.lock, **/composer.json, **/composer.lock, **/Cargo.toml, **/Cargo.lock, **/go.mod, **/go.sum, **/Gemfile, **/Gemfile.lock, **/*dependabot*, **/*renovate*"
 ---
 
 # Dependency Versioning

--- a/rules/error-handling.md
+++ b/rules/error-handling.md
@@ -1,8 +1,17 @@
 ---
-description: Error handling standards for all application code
+description: Error handling standards for application code
+paths: "**/api/**, **/routes/**, **/handlers/**, **/endpoints/**, **/services/**, **/middleware/**, **/*error*, **/*exception*"
 ---
 
 # Error Handling
+
+> **Existing codebases: match what is already there.** The response-format rules
+> below describe the target for a NEW API. A project that already has a
+> consistent error format keeps that format — introducing a second one on a
+> single endpoint is worse than the imperfection it replaces. Migrating an
+> existing API to a new format is its own deliberate piece of work, never a
+> side effect of an unrelated change. Check what the codebase does before
+> applying the format rules.
 
 - Never swallow errors — every error must be either handled (corrective action) or propagated (caller deals with it). Logging and continuing is not handling.
 - Add context when propagating — each layer adds what it was doing. Final message reads as a chain: `"create order: charge payment: POST /payments: connection refused"`

--- a/rules/payments.md
+++ b/rules/payments.md
@@ -1,5 +1,6 @@
 ---
 description: Payment provider (PSP) onboarding and integration rules
+paths: "**/*payment*, **/*billing*, **/*checkout*, **/*subscription*, **/*invoice*, **/*stripe*, **/*mollie*, **/*adyen*, **/*multisafepay*, **/*paypal*, **/*psp*"
 ---
 
 # Payments

--- a/rules/structured-logging.md
+++ b/rules/structured-logging.md
@@ -1,5 +1,6 @@
 ---
 description: Structured logging standards for application code
+paths: "**/*log*, **/api/**, **/routes/**, **/handlers/**, **/endpoints/**, **/services/**, **/worker*/**, **/tasks/**, **/middleware/**"
 ---
 
 # Structured Logging


### PR DESCRIPTION
## Waarom

Bij het verfijnen van PAM-issue #2516 bleek een acceptatiecriterium te eisen dat
de 422-response RFC 9457 Problem Details volgt. PAM gebruikt overal zijn eigen
`APIErrorResponse`-formaat en kent RFC 9457 nergens — dat criterium zou één
endpoint een afwijkend foutformaat hebben gegeven, naast de rest van de API.

De eis kwam niet uit het project maar uit `rules/error-handling.md` hier, dat in
elke sessie voor elk project meegeladen wordt. Twee dingen gingen mis:

1. **Formulering.** "API error responses **must use** RFC 9457" leest als een
   uitspraak over de huidige codebase, terwijl het een doel voor nieuwe API's
   is. Er stond niets over wat te doen in een bestaand project met een eigen
   conventie.
2. **Laadmoment.** Negen van de veertien regelbestanden hadden geen `paths:` in
   de frontmatter en werden dus onvoorwaardelijk geladen — inclusief
   ontwerpstandaarden die alleen op API- of payment-code slaan.

## Wat er verandert

### Scoping via `paths:`

Zes bestanden krijgen een `paths:`-key, zodat ze laden wanneer een matchend
bestand gelezen wordt in plaats van bij sessiestart. Het mechanisme bestond al
(`testing.md`, `documentation.md` en `stripe-testing.md` gebruikten het) — het
was alleen niet toegepast waar het het meest scheelt.

| | Bestanden | Omvang |
|---|---|---|
| Altijd geladen | `think-before-coding`, `code-review`, `git-pr-workflow`, `data-integrity` | ~5KB |
| Scoped | de overige negen | ~23KB, alleen bij matchende bestanden |

Het criterium voor de indeling is **niet** "vaak vs. zelden nodig", maar of een
regel een *verkeerde aanname corrigeert* of een *bewuste keuze informeert*.
`Closes #X` sluit een issue ook als je erbij schrijft dat het niet moet — die
regel moet aankomen juist wanneer je denkt dat je het weet, dus scopen zou hem
onbruikbaar maken. Een RFC 9457-standaard zoek je op op het moment dat je
error-handling ontwerpt.

Volgens de Claude Code-documentatie triggert `paths:` bij het **lezen** van een
matchend bestand, niet bij het bewerken. Een ontwerpregel arriveert dus voordat
er iets ontworpen is.

### Uitzondering voor bestaande codebases

`api-design.md` en `error-handling.md` krijgen expliciet: een project met een
bestaande conventie houdt die conventie, en migratie is apart werk — nooit
bijvangst van een ongerelateerde wijziging.

### venv-zoekpad (`bin/`)

Losse fix die al ongecommit in de working tree stond. Beide wrappers misten het
geval waarin CWD een zustermap is van de directory met de venv: draaien vanuit
`frontend/` in een project met de venv in `backend/` matchte niets, waarna de
loop doorviel naar de system-interpreter. Het draaide gewoon door — geen fout,
alleen de verkeerde Python en dependency-set.

Toegevoegd: `../backend/.venv` en `../backend/venv` aan alle drie de zoeklijsten,
met commentaar waarom ze er staan.

## Verificatie

- Frontmatter van alle 14 bestanden valideert als YAML; splitsing gecontroleerd
- `shellcheck` schoon op beide scripts
- venv-detectie getest vanuit project root, `backend/`, `backend/app/`,
  `frontend/` en de `PAM-dev1`-worktree — alle vijf resolven correct, en
  `frontend/` gaat nu naar `../backend/.venv` in plaats van system-python

## Let op

De scoping wordt pas effectief zodra dit in `main` zit: `~/.claude/rules`
symlinkt naar de working tree van deze repo, dus de regels laden zoals de
uitgecheckte branch ze heeft.
