### PR TITLE
fix(bin): make the CI gate fail closed instead of merging before checks exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
 | `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents) |
-| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on required CI checks, merge, return to base (for `/implement-epic`) |
+| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). Repos without CI need `--no-ci-wait` |
 
 ### Project audits
 

--- a/bin/git-push-pr-merge.sh
+++ b/bin/git-push-pr-merge.sh
@@ -37,7 +37,7 @@
 #   --no-ci-wait                Merge immediately without waiting for CI checks
 #   --ci-timeout <secs>         Max time registered checks may stay pending (default: 900)
 #   --ci-grace <secs>           Max time checks may take to register (default: 120)
-#   --ci-poll-interval <secs>   Polling interval while waiting (default: 15)
+#   --ci-poll-interval <secs>   Polling interval while waiting (default: 15, must be >= 1)
 
 set -euo pipefail
 
@@ -106,6 +106,22 @@ if [[ -z "$BODY_FILE" ]]; then
 fi
 if [[ ! -f "$BODY_FILE" ]]; then
     echo "Error: Body file not found: $BODY_FILE" >&2
+    exit 1
+fi
+
+# Both deadlines advance by CI_POLL_INTERVAL, so 0 (or a non-number) would spin
+# forever without ever reaching CI_TIMEOUT or CI_GRACE — a hung gate, which for a
+# fail-closed design is worse than a wrong answer.
+if ! [[ "$CI_POLL_INTERVAL" =~ ^[0-9]+$ ]] || [[ "$CI_POLL_INTERVAL" -lt 1 ]]; then
+    echo "Error: --ci-poll-interval must be a positive integer (got: $CI_POLL_INTERVAL)" >&2
+    exit 1
+fi
+if ! [[ "$CI_TIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "Error: --ci-timeout must be a non-negative integer (got: $CI_TIMEOUT)" >&2
+    exit 1
+fi
+if ! [[ "$CI_GRACE" =~ ^[0-9]+$ ]]; then
+    echo "Error: --ci-grace must be a non-negative integer (got: $CI_GRACE)" >&2
     exit 1
 fi
 
@@ -208,8 +224,13 @@ wait_for_ci_gate() {
         # Exit 0 (all passed) or exit 1 (a check failed) both carry a full JSON
         # payload. Anything else, or an exit 1 whose payload does not parse, is a
         # real gh error: retry once, then fail closed.
+        # `if type == "array"` matters: jq's `length` also succeeds on objects,
+        # strings and numbers, so an API error body like {"message":"Not Found"}
+        # would yield a plausible count and then blow up in the `.[]` queries
+        # below — which, with set -e suppressed inside `if ! wait_for_ci_gate`,
+        # left both name lists empty and reported PASS on no evidence at all.
         local parsed_count
-        parsed_count=$(echo "$checks_json" | jq -r 'length' 2>/dev/null || true)
+        parsed_count=$(echo "$checks_json" | jq -r 'if type == "array" then length else "notarray" end' 2>/dev/null || true)
 
         if [[ "$checks_exit" -ne 0 && "$checks_exit" -ne 1 ]] || ! [[ "$parsed_count" =~ ^[0-9]+$ ]]; then
             if [[ "$checks_exit" -ne 0 && "$retried_transient" -eq 0 ]]; then

--- a/bin/git-push-pr-merge.sh
+++ b/bin/git-push-pr-merge.sh
@@ -9,17 +9,25 @@
 #
 # What it does:
 #   1. Push current branch to origin (with -u)
-#   2. Create PR against base branch
-#   3. If merging: wait for required CI checks to go green (see CI gate below)
+#   2. Reuse the open PR for this branch, or create one against the base branch
+#   3. If merging: wait for CI checks to go green (see CI gate below)
 #   4. Merge PR (--merge --delete-branch)
 #   5. Checkout base branch and pull
 #
 # CI gate (skipped entirely when --no-merge is set):
-#   After PR creation, required checks (`gh pr checks --required`) are polled
-#   until they all pass, one fails, or --ci-timeout elapses. A repo with no
-#   checks configured skips the gate and merges as before. On failure or
-#   timeout the PR is left open, a `CI_GATE: FAIL|TIMEOUT` line is printed,
-#   and the script exits non-zero so callers can react.
+#   After PR creation, all reported checks (`gh pr checks`) are polled until
+#   they all pass, one fails, or a deadline elapses. The gate FAILS CLOSED: it
+#   only merges on positive evidence that every check is green.
+#
+#   Checks do not exist for the first few seconds after a push — GitHub has to
+#   create the runs. That gap is a separate --ci-grace deadline (default 120s),
+#   not a reason to skip: if no checks appear within it the gate prints
+#   `CI_GATE: FAIL — no checks appeared` and does not merge. Use --no-ci-wait
+#   for repos that genuinely have no CI (this toolkit repo is one).
+#
+#   On FAIL/TIMEOUT the PR is left open, a `CI_GATE: FAIL|TIMEOUT` line is
+#   printed, and the script exits non-zero so callers can react. Re-running
+#   with the same arguments reuses the open PR and re-runs the gate.
 #
 # Options:
 #   --base <branch>            Target branch for the PR (required)
@@ -27,7 +35,8 @@
 #   --body-file <path>         File containing PR body (required)
 #   --no-merge                 Create PR but don't merge (for manual review) — CI gate is skipped
 #   --no-ci-wait                Merge immediately without waiting for CI checks
-#   --ci-timeout <secs>         Max time to wait for checks (default: 900)
+#   --ci-timeout <secs>         Max time registered checks may stay pending (default: 900)
+#   --ci-grace <secs>           Max time checks may take to register (default: 120)
 #   --ci-poll-interval <secs>   Polling interval while waiting (default: 15)
 
 set -euo pipefail
@@ -39,6 +48,7 @@ DO_MERGE=1
 CI_WAIT=1
 CI_TIMEOUT=900
 CI_POLL_INTERVAL=15
+CI_GRACE=120
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -68,6 +78,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --ci-poll-interval)
             CI_POLL_INTERVAL="$2"
+            shift 2
+            ;;
+        --ci-grace)
+            CI_GRACE="$2"
             shift 2
             ;;
         *)
@@ -104,17 +118,51 @@ fi
 echo "=== Pushing $CURRENT_BRANCH to origin ==="
 git push -u origin "$CURRENT_BRANCH"
 
-echo "=== Creating PR: $TITLE ==="
-PR_URL=$(gh pr create --title "$TITLE" --base "$BASE" --body-file "$BODY_FILE")
-PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
+# PR creation is idempotent: a blocked CI gate leaves the PR open, and the
+# implement-epic recovery path re-runs this script with identical arguments
+# (up to 3 attempts). Without the reuse check, attempt 2 dies on "a pull
+# request for branch ... already exists" instead of re-running the gate.
+EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --base "$BASE" --state open --json number,url)
+PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.[0].number // empty')
+PR_URL=$(echo "$EXISTING_PR" | jq -r '.[0].url // empty')
 
-echo "Created PR #$PR_NUMBER: $PR_URL"
+if [[ -n "$PR_NUMBER" ]]; then
+    echo "=== Reusing existing PR #$PR_NUMBER: $PR_URL ==="
+else
+    echo "=== Creating PR: $TITLE ==="
+    PR_URL=$(gh pr create --title "$TITLE" --base "$BASE" --body-file "$BODY_FILE")
+    PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K[0-9]+')
+    echo "Created PR #$PR_NUMBER: $PR_URL"
+fi
 
-# wait_for_ci_gate: polls required checks on $PR_NUMBER until they all pass,
-# one fails, or CI_TIMEOUT elapses. Prints a CI_GATE status line and returns
-# non-zero on FAIL/TIMEOUT/unverifiable so the caller can bail before merging.
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "Error: could not determine PR number from: $PR_URL" >&2
+    exit 1
+fi
+
+# wait_for_ci_gate: polls the checks on $PR_NUMBER until they all pass, one
+# fails, or a deadline elapses. Prints a CI_GATE status line and returns
+# non-zero on FAIL/TIMEOUT so the caller can bail before merging.
+#
+# Design principle: fail closed. Every branch that cannot positively establish
+# "all checks green" must block the merge. The previous version failed open on
+# "no checks reported" and merged PRs three seconds before their checks even
+# started (issue #32).
+#
+# Two separate deadlines:
+#   CI_GRACE   — how long checks may take to REGISTER. GitHub creates check runs
+#                a few seconds after the push, so an empty set right after
+#                `gh pr create` means "not yet", not "this repo has no CI".
+#   CI_TIMEOUT — how long registered checks may stay pending.
+#
+# `gh pr checks` exit codes (see `gh pr checks --help`):
+#   0 = all checks passed        8 = checks pending
+#   1 = a check failed, OR no checks reported, OR a real gh error
+# Exit 1 is overloaded, so it is disambiguated by stderr and by whether the
+# JSON payload parses into checks.
 wait_for_ci_gate() {
     local elapsed=0
+    local grace_elapsed=0
     local retried_transient=0
     local stderr_file
     stderr_file=$(mktemp)
@@ -123,40 +171,83 @@ wait_for_ci_gate() {
     while true; do
         local checks_json
         local checks_exit=0
-        checks_json=$(gh pr checks "$PR_NUMBER" --required --json name,bucket 2>"$stderr_file") || checks_exit=$?
+        checks_json=$(gh pr checks "$PR_NUMBER" --json name,bucket 2>"$stderr_file") || checks_exit=$?
         local checks_stderr
         checks_stderr=$(cat "$stderr_file" 2>/dev/null || true)
 
-        if [[ "$checks_exit" -ne 0 ]]; then
-            if echo "$checks_stderr" | grep -qi "no checks reported"; then
-                echo "CI_GATE: SKIP — no checks configured"
-                return 0
+        # No checks registered yet: wait out the grace period, then fail closed.
+        # Skipping here would be the same fail-open assumption, just 120s later —
+        # a workflow file with a syntax error reads identically to "no CI".
+        if [[ "$checks_exit" -ne 0 ]] && echo "$checks_stderr" | grep -qi "no checks reported"; then
+            if [[ "$grace_elapsed" -ge "$CI_GRACE" ]]; then
+                echo "CI_GATE: FAIL — no checks appeared after ${CI_GRACE}s (use --no-ci-wait for repos without CI)"
+                return 1
             fi
-            # Transient gh error (rate limit, network blip): retry once, then fail closed.
-            if [[ "$retried_transient" -eq 0 ]]; then
+            echo "CI gate: no checks registered yet, waiting (${grace_elapsed}s/${CI_GRACE}s)" >&2
+            sleep "$CI_POLL_INTERVAL"
+            grace_elapsed=$((grace_elapsed + CI_POLL_INTERVAL))
+            continue
+        fi
+
+        # Exit 8 means pending. gh still prints the payload, but treat a missing
+        # or unparseable one as "pending with unknown names" rather than an error.
+        if [[ "$checks_exit" -eq 8 ]]; then
+            local pending_names_8
+            pending_names_8=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")' 2>/dev/null || true)
+            [[ -z "$pending_names_8" ]] && pending_names_8="(pending)"
+
+            if [[ "$elapsed" -ge "$CI_TIMEOUT" ]]; then
+                echo "CI_GATE: TIMEOUT — still pending: $pending_names_8"
+                return 1
+            fi
+            sleep "$CI_POLL_INTERVAL"
+            elapsed=$((elapsed + CI_POLL_INTERVAL))
+            continue
+        fi
+
+        # Exit 0 (all passed) or exit 1 (a check failed) both carry a full JSON
+        # payload. Anything else, or an exit 1 whose payload does not parse, is a
+        # real gh error: retry once, then fail closed.
+        local parsed_count
+        parsed_count=$(echo "$checks_json" | jq -r 'length' 2>/dev/null || true)
+
+        if [[ "$checks_exit" -ne 0 && "$checks_exit" -ne 1 ]] || ! [[ "$parsed_count" =~ ^[0-9]+$ ]]; then
+            if [[ "$checks_exit" -ne 0 && "$retried_transient" -eq 0 ]]; then
                 retried_transient=1
-                echo "CI gate: transient error from gh, retrying once: $checks_stderr" >&2
+                echo "CI gate: transient error from gh (exit $checks_exit), retrying once: $checks_stderr" >&2
                 sleep 1
                 continue
             fi
-            echo "CI_GATE: FAIL — unable to verify checks: $checks_stderr"
+            if [[ "$checks_exit" -eq 0 ]]; then
+                echo "CI_GATE: FAIL — unable to parse checks output from gh"
+            else
+                echo "CI_GATE: FAIL — unable to verify checks: $checks_stderr"
+            fi
             return 1
         fi
 
-        local jq_exit=0
         local fail_names
-        fail_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | map(.name) | join(",")') || jq_exit=$?
+        fail_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | map(.name) | join(",")')
         local pending_names
-        pending_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")') || jq_exit=$?
-
-        if [[ "$jq_exit" -ne 0 ]]; then
-            echo "CI_GATE: FAIL — unable to parse checks output from gh"
-            return 1
-        fi
+        pending_names=$(echo "$checks_json" | jq -r '[.[] | select(.bucket == "pending")] | map(.name) | join(",")')
 
         if [[ -n "$fail_names" ]]; then
             echo "CI_GATE: FAIL — $fail_names"
             return 1
+        fi
+
+        # An empty set with exit 0 is what --required used to return on every
+        # unprotected branch. Without --required it should not happen, but if it
+        # does it is not evidence of green — treat it as "not registered yet".
+        if [[ "$parsed_count" -eq 0 ]]; then
+            if [[ "$grace_elapsed" -ge "$CI_GRACE" ]]; then
+                echo "CI_GATE: FAIL — no checks appeared after ${CI_GRACE}s (use --no-ci-wait for repos without CI)"
+                return 1
+            fi
+            echo "CI gate: check set still empty, waiting (${grace_elapsed}s/${CI_GRACE}s)" >&2
+            sleep "$CI_POLL_INTERVAL"
+            grace_elapsed=$((grace_elapsed + CI_POLL_INTERVAL))
+            continue
         fi
 
         if [[ -z "$pending_names" ]]; then

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -9,12 +9,14 @@
 #    5. Pending then pass within timeout -> CI_GATE: PASS, merges
 #    6. Transient gh error retried once -> CI_GATE: PASS, merges
 #   6b. Malformed JSON from gh          -> CI_GATE: FAIL, no merge
+#   6c. Valid JSON that is not an array -> CI_GATE: FAIL, no merge
 #    7. --no-ci-wait                    -> merges without checking, regardless of check state
 #    8. --no-merge                      -> CI gate skipped entirely, unaffected
 #    9. Checks appear late, within grace -> CI_GATE: PASS, merges
 #   10. Grace period elapses, no checks  -> CI_GATE: FAIL, no merge
 #   11. gh exit 8                        -> read as pending, not "unable to verify"
 #   12. Re-run with an existing open PR   -> reuses it, gate runs again
+#   13. --ci-poll-interval 0              -> rejected up front, never spins
 #
 # Each scenario builds a throwaway repo and a fake `gh`/`git push` stub so it
 # never touches a real GitHub repo.
@@ -139,7 +141,10 @@ case "$1 $2" in
                 ;;
             exit8-then-pass)
                 # Exit 8 with no parseable payload — pending, not "unverifiable".
-                if [ "$count" -lt 2 ]; then
+                # Must exit 8 more than once: the transient-error branch retries
+                # a single time, so a one-shot exit 8 would also go green there
+                # and the scenario could not tell the two paths apart.
+                if [ "$count" -lt 4 ]; then
                     exit 8
                 fi
                 echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
@@ -156,6 +161,13 @@ case "$1 $2" in
                 ;;
             malformed-json)
                 echo 'not valid json {{{'
+                exit 0
+                ;;
+            object-json)
+                # Valid JSON but NOT an array — e.g. a GitHub API error body.
+                # jq's `length` succeeds on objects, so this used to pass the
+                # payload guard and then report PASS on zero green evidence.
+                echo '{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}'
                 exit 0
                 ;;
         esac
@@ -211,7 +223,9 @@ assert_contains() {
     local needle="$2"
     local haystack="$3"
 
-    if echo "$haystack" | grep -qF "$needle"; then
+    # -e is required: needles starting with `--` would otherwise be parsed as
+    # grep options and silently never match.
+    if echo "$haystack" | grep -qF -e "$needle"; then
         echo "PASS: $case_name (found '$needle')"
         pass=$((pass + 1))
     else
@@ -268,7 +282,7 @@ assert_not_contains() {
     local needle="$2"
     local haystack="$3"
 
-    if echo "$haystack" | grep -qF "$needle"; then
+    if echo "$haystack" | grep -qF -e "$needle"; then
         echo "FAIL: $case_name (unexpectedly found '$needle')"
         echo "--- output ---"
         echo "$haystack"
@@ -371,6 +385,21 @@ assert_exit "malformed json: exit code" "1" "$(cat "$repo6b/last-exit.txt")"
 assert_file_absent "malformed json: no merge" "$repo6b/merged"
 rm -rf "$repo6b"
 
+# --- Scenario 6c: valid JSON that is not an array -> fail closed, no merge ---
+# jq `length` answers for objects too, so this payload satisfied a naive numeric
+# guard and then made the `.[]` queries error out. set -e is suppressed inside
+# `if ! wait_for_ci_gate`, so both name lists came back empty and the gate
+# announced PASS without a single green check.
+repo6c=$(make_repo)
+make_fake_gh "$repo6c"
+echo "Test PR body" > "$repo6c/body.md"
+run_case "object json" "$repo6c" "object-json"
+assert_contains "object json: CI_GATE line" "CI_GATE: FAIL" "$(cat "$repo6c/last-output.txt")"
+assert_not_contains "object json: never reports PASS" "CI_GATE: PASS" "$(cat "$repo6c/last-output.txt")"
+assert_exit "object json: exit code" "1" "$(cat "$repo6c/last-exit.txt")"
+assert_file_absent "object json: no merge" "$repo6c/merged"
+rm -rf "$repo6c"
+
 # --- Scenario 7: --no-ci-wait skips the gate even with failing checks ---
 repo7=$(make_repo)
 make_fake_gh "$repo7"
@@ -438,6 +467,18 @@ assert_contains "re-run: gate ran again" "CI_GATE: PASS" "$(cat "$repo12/last-ou
 assert_exit "re-run: exit code" "0" "$(cat "$repo12/last-exit.txt")"
 assert_file_present "re-run: merge happened" "$repo12/merged"
 rm -rf "$repo12"
+
+# --- Scenario 13: --ci-poll-interval 0 is rejected instead of spinning forever ---
+# Both deadlines advance by the poll interval, so 0 would never reach CI_TIMEOUT
+# or CI_GRACE: the gate would hammer `gh` in a tight loop and never return.
+repo13=$(make_repo)
+make_fake_gh "$repo13"
+echo "Test PR body" > "$repo13/body.md"
+run_case "zero poll interval" "$repo13" "pending-forever" --ci-timeout 2 --ci-poll-interval 0
+assert_contains "zero poll: rejected" "--ci-poll-interval must be a positive integer" "$(cat "$repo13/last-output.txt")"
+assert_exit "zero poll: exit code" "1" "$(cat "$repo13/last-exit.txt")"
+assert_file_absent "zero poll: no merge" "$repo13/merged"
+rm -rf "$repo13"
 
 echo ""
 echo "Results: $pass passed, $fail failed"

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
-# Regression tests for git-push-pr-merge.sh's CI gate (issue #13).
+# Regression tests for git-push-pr-merge.sh's CI gate (issues #13, #32).
 #
 # Covers:
-#   1. No checks configured           -> CI_GATE: SKIP, merges
-#   2. Required checks pass           -> CI_GATE: PASS, merges
-#   3. A required check fails         -> CI_GATE: FAIL, no merge, exit non-zero
-#   4. Checks stuck pending (timeout) -> CI_GATE: TIMEOUT, no merge, exit non-zero
-#   5. --no-ci-wait                   -> merges without checking, regardless of check state
-#   6. --no-merge                     -> CI gate skipped entirely, unaffected
+#    1. No checks reported at all      -> CI_GATE: FAIL after grace, no merge (fail closed)
+#    2. Checks pass                    -> CI_GATE: PASS, merges
+#    3. A check fails                  -> CI_GATE: FAIL, no merge, exit non-zero
+#    4. Checks stuck pending (timeout)  -> CI_GATE: TIMEOUT, no merge, exit non-zero
+#    5. Pending then pass within timeout -> CI_GATE: PASS, merges
+#    6. Transient gh error retried once -> CI_GATE: PASS, merges
+#   6b. Malformed JSON from gh          -> CI_GATE: FAIL, no merge
+#    7. --no-ci-wait                    -> merges without checking, regardless of check state
+#    8. --no-merge                      -> CI gate skipped entirely, unaffected
+#    9. Checks appear late, within grace -> CI_GATE: PASS, merges
+#   10. Grace period elapses, no checks  -> CI_GATE: FAIL, no merge
+#   11. gh exit 8                        -> read as pending, not "unable to verify"
+#   12. Re-run with an existing open PR   -> reuses it, gate runs again
 #
 # Each scenario builds a throwaway repo and a fake `gh`/`git push` stub so it
 # never touches a real GitHub repo.
@@ -34,9 +41,17 @@ make_repo() {
 }
 
 # Builds a fake `gh` binary in $1/bin that:
-#   - `gh pr create` prints a fake PR URL
+#   - `gh pr list` reports an existing open PR only if $1/existing-pr is present
+#   - `gh pr create` prints a fake PR URL and records the call in $1/create-count
 #   - `gh pr checks` behavior driven by $1/checks-state (see scenarios below)
 #   - `gh pr merge` records that merge happened into $1/merged
+#
+# The stub mirrors two real `gh pr checks` behaviours the earlier version got
+# wrong, which is why the suite never caught issue #32:
+#   - `--required` on a branch without protection returns an EMPTY set with
+#     exit 0 — not the actual checks. Any state combined with --required
+#     therefore looks green, which is the fail-open bug.
+#   - Pending checks exit 8; failing checks exit 1 (see `gh pr checks --help`).
 make_fake_gh() {
     local workdir="$1"
     local bindir="$workdir/bin"
@@ -47,20 +62,56 @@ make_fake_gh() {
 WORKDIR="$FAKE_GH_WORKDIR"
 
 case "$1 $2" in
+    "pr list")
+        # Only reports a PR when the scenario planted one (re-run case).
+        if [ -f "$WORKDIR/existing-pr" ]; then
+            echo '[{"number":42,"url":"https://github.com/example/repo/pull/42"}]'
+        else
+            echo '[]'
+        fi
+        exit 0
+        ;;
     "pr create")
+        count_file="$WORKDIR/create-count"
+        count=$(cat "$count_file" 2>/dev/null || echo "0")
+        echo $((count + 1)) > "$count_file"
         echo "https://github.com/example/repo/pull/42"
         exit 0
         ;;
     "pr checks")
-        # checks-state file contains one of: none, pass, fail, pending-then-pass, pending-forever, ratelimit-then-pass
+        # checks-state file contains one of: none, none-then-pass, none-forever,
+        # pass, fail, pending-then-pass, pending-forever, exit8-then-pass,
+        # ratelimit-then-pass, malformed-json
         state=$(cat "$WORKDIR/checks-state" 2>/dev/null || echo "none")
         count_file="$WORKDIR/checks-call-count"
         count=$(cat "$count_file" 2>/dev/null || echo "0")
         count=$((count + 1))
         echo "$count" > "$count_file"
 
+        # Real gh: --required on a branch without protection yields an empty
+        # set with exit 0, regardless of the checks that actually ran.
+        for arg in "$@"; do
+            if [ "$arg" = "--required" ]; then
+                echo "[]"
+                exit 0
+            fi
+        done
+
         case "$state" in
             none)
+                echo "no checks reported on the '42' pull request" >&2
+                exit 1
+                ;;
+            none-then-pass)
+                # Checks not registered yet, then they appear and pass.
+                if [ "$count" -lt 3 ]; then
+                    echo "no checks reported on the '42' pull request" >&2
+                    exit 1
+                fi
+                echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
+                exit 0
+                ;;
+            none-forever)
                 echo "no checks reported on the '42' pull request" >&2
                 exit 1
                 ;;
@@ -69,19 +120,29 @@ case "$1 $2" in
                 exit 0
                 ;;
             fail)
+                # Real gh exits 1 when checks are failing.
                 echo '[{"name":"build","state":"FAILURE","bucket":"fail"}]'
-                exit 0
+                exit 1
                 ;;
             pending-then-pass)
                 if [ "$count" -lt 2 ]; then
                     echo '[{"name":"build","state":"PENDING","bucket":"pending"}]'
+                    exit 8
                 else
                     echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
+                    exit 0
                 fi
-                exit 0
                 ;;
             pending-forever)
                 echo '[{"name":"build","state":"PENDING","bucket":"pending"}]'
+                exit 8
+                ;;
+            exit8-then-pass)
+                # Exit 8 with no parseable payload — pending, not "unverifiable".
+                if [ "$count" -lt 2 ]; then
+                    exit 8
+                fi
+                echo '[{"name":"build","state":"SUCCESS","bucket":"pass"}]'
                 exit 0
                 ;;
             ratelimit-then-pass)
@@ -133,7 +194,7 @@ run_case() {
     local extra_args=("$@")
 
     echo "$checks_state" > "$repo/checks-state"
-    rm -f "$repo/merged" "$repo/checks-call-count"
+    rm -f "$repo/merged" "$repo/checks-call-count" "$repo/create-count"
 
     set +e
     output=$(cd "$repo" && PATH="$repo/bin:$PATH" "$TARGET" --base main --title "Test PR" --body-file "$repo/body.md" "${extra_args[@]}" 2>&1)
@@ -202,14 +263,52 @@ assert_file_present() {
     fi
 }
 
-# --- Scenario 1: no checks configured -> skip gate, merge proceeds ---
+assert_not_contains() {
+    local case_name="$1"
+    local needle="$2"
+    local haystack="$3"
+
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "FAIL: $case_name (unexpectedly found '$needle')"
+        echo "--- output ---"
+        echo "$haystack"
+        echo "--------------"
+        fail=$((fail + 1))
+    else
+        echo "PASS: $case_name (no '$needle')"
+        pass=$((pass + 1))
+    fi
+}
+
+assert_file_content() {
+    local case_name="$1"
+    local path="$2"
+    local expected="$3"
+    local actual
+    actual=$(cat "$path" 2>/dev/null || echo "<absent>")
+
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $case_name ($expected)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $case_name (expected '$expected', got '$actual')"
+        fail=$((fail + 1))
+    fi
+}
+
+# --- Scenario 1: no checks reported at all -> fail closed after grace, no merge ---
+# Previously asserted CI_GATE: SKIP + merge. That WAS the bug (issue #32): a PR
+# whose checks have not registered yet is indistinguishable from a repo without
+# CI, and merging on that assumption merged three red branches. "No checks" now
+# means wait, then fail closed; --no-ci-wait is the deliberate escape hatch.
 repo1=$(make_repo)
 make_fake_gh "$repo1"
 echo "Test PR body" > "$repo1/body.md"
-run_case "no checks" "$repo1" "none"
-assert_contains "no checks: CI_GATE line" "CI_GATE: SKIP" "$(cat "$repo1/last-output.txt")"
-assert_exit "no checks: exit code" "0" "$(cat "$repo1/last-exit.txt")"
-assert_file_present "no checks: merge happened" "$repo1/merged"
+run_case "no checks" "$repo1" "none" --ci-grace 2 --ci-poll-interval 1
+assert_contains "no checks: CI_GATE line" "CI_GATE: FAIL" "$(cat "$repo1/last-output.txt")"
+assert_contains "no checks: reason names grace period" "no checks appeared" "$(cat "$repo1/last-output.txt")"
+assert_exit "no checks: exit code" "1" "$(cat "$repo1/last-exit.txt")"
+assert_file_absent "no checks: no merge" "$repo1/merged"
 rm -rf "$repo1"
 
 # --- Scenario 2: required checks pass -> merge proceeds ---
@@ -290,6 +389,55 @@ run_case "no-merge path" "$repo8" "fail" --no-merge
 assert_exit "no-merge: exit code" "0" "$(cat "$repo8/last-exit.txt")"
 assert_file_absent "no-merge: no merge" "$repo8/merged"
 rm -rf "$repo8"
+
+# --- Scenario 9: checks appear late but within the grace period -> PASS, merge ---
+# The original failure mode: merged 3s before the check even started. The gate
+# must sit through the registration gap instead of reading it as "no CI".
+repo9=$(make_repo)
+make_fake_gh "$repo9"
+echo "Test PR body" > "$repo9/body.md"
+run_case "checks appear late" "$repo9" "none-then-pass" --ci-grace 30 --ci-poll-interval 1
+assert_contains "late checks: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo9/last-output.txt")"
+assert_exit "late checks: exit code" "0" "$(cat "$repo9/last-exit.txt")"
+assert_file_present "late checks: merge happened" "$repo9/merged"
+rm -rf "$repo9"
+
+# --- Scenario 10: grace period elapses with no checks -> FAIL closed, no merge ---
+repo10=$(make_repo)
+make_fake_gh "$repo10"
+echo "Test PR body" > "$repo10/body.md"
+run_case "grace expires" "$repo10" "none-forever" --ci-grace 2 --ci-poll-interval 1
+assert_contains "grace expires: CI_GATE line" "CI_GATE: FAIL" "$(cat "$repo10/last-output.txt")"
+assert_contains "grace expires: reason" "no checks appeared" "$(cat "$repo10/last-output.txt")"
+assert_exit "grace expires: exit code" "1" "$(cat "$repo10/last-exit.txt")"
+assert_file_absent "grace expires: no merge" "$repo10/merged"
+rm -rf "$repo10"
+
+# --- Scenario 11: exit 8 reads as pending, not "unable to verify" ---
+repo11=$(make_repo)
+make_fake_gh "$repo11"
+echo "Test PR body" > "$repo11/body.md"
+run_case "exit 8 is pending" "$repo11" "exit8-then-pass" --ci-timeout 30 --ci-poll-interval 1
+assert_contains "exit 8: CI_GATE line" "CI_GATE: PASS" "$(cat "$repo11/last-output.txt")"
+assert_not_contains "exit 8: not misread as unverifiable" "unable to verify" "$(cat "$repo11/last-output.txt")"
+assert_exit "exit 8: exit code" "0" "$(cat "$repo11/last-exit.txt")"
+assert_file_present "exit 8: merge happened" "$repo11/merged"
+rm -rf "$repo11"
+
+# --- Scenario 12: re-run on a branch that already has a PR -> reuse, gate re-runs ---
+# implement-epic's CI_GATE_BLOCKED recovery re-runs with identical arguments.
+# Without an idempotent create, attempt 2 dies on gh instead of re-gating.
+repo12=$(make_repo)
+make_fake_gh "$repo12"
+echo "Test PR body" > "$repo12/body.md"
+touch "$repo12/existing-pr"
+run_case "re-run with existing PR" "$repo12" "pass" --ci-timeout 30 --ci-poll-interval 1
+assert_contains "re-run: reuses PR" "Reusing existing PR #42" "$(cat "$repo12/last-output.txt")"
+assert_file_content "re-run: no second create" "$repo12/create-count" "<absent>"
+assert_contains "re-run: gate ran again" "CI_GATE: PASS" "$(cat "$repo12/last-output.txt")"
+assert_exit "re-run: exit code" "0" "$(cat "$repo12/last-exit.txt")"
+assert_file_present "re-run: merge happened" "$repo12/merged"
+rm -rf "$repo12"
 
 echo ""
 echo "Results: $pass passed, $fail failed"

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -268,11 +268,14 @@ Read only the files relevant to your issue. Do NOT skip this step.
    - Commit any remaining uncommitted work: `~/.claude/bin/git-commit.sh "concise descriptive message"`
    - Write PR body to /tmp/pr-body.md using the Write tool, then push + PR + merge in one command:
      `~/.claude/bin/git-push-pr-merge.sh --base <feature_branch> --title "<title>" --body-file /tmp/pr-body.md`
-   - This script pushes, creates the PR, waits for required CI checks, merges it, and returns to the feature branch automatically
-   - **If the script exits non-zero with `STATUS: CI_GATE_BLOCKED`:** the PR was left open — checks failed or timed out.
-     - Read the `CI_GATE: FAIL — <check names>` or `CI_GATE: TIMEOUT — <check names>` line to identify the failing/stuck checks
-     - Investigate the failure (`gh pr checks <PR_NUMBER>`, CI logs), fix at root cause, commit, push to the same branch
-     - Re-run `~/.claude/bin/git-push-pr-merge.sh` with the same arguments to re-trigger the gate
+   - This script pushes, creates the PR, waits for the CI checks, merges it, and returns to the feature branch automatically
+   - The gate **fails closed**: it merges only on positive evidence that every check is green. Expect each sub-PR to take 1-2 minutes longer than a blind merge, and expect blocks where a red branch used to slip through silently — that is the gate working.
+   - **If the script exits non-zero with `STATUS: CI_GATE_BLOCKED`:** the PR was left open. Read the `CI_GATE:` line to see why:
+     - `FAIL — <check names>` → those checks are red. Investigate (`gh pr checks <PR_NUMBER>`, CI logs), fix at root cause, commit, push to the same branch.
+     - `TIMEOUT — still pending: <check names>` → checks never finished. Check whether the run is stuck or the queue is slow before retrying.
+     - `FAIL — no checks appeared after <N>s` → no check ever registered. Either the workflow file is broken (fix it), or the repo genuinely has no CI — in that case, and only then, re-run with `--no-ci-wait`.
+     - `FAIL — unable to verify checks` → `gh` itself failed. Verify auth/rate limits; do not work around it by disabling the gate.
+     - Then re-run `~/.claude/bin/git-push-pr-merge.sh` with the same arguments to re-trigger the gate. The script reuses the open PR, so re-running is safe and does not create a duplicate.
      - Up to 3 fix-and-retry attempts; if still blocked, leave the PR open and report the blocker instead of forcing a merge
 
 ## Auth Impact Check (only include if auth_impact is true)


### PR DESCRIPTION
Closes #32

The CI gate in `bin/git-push-pr-merge.sh` merged six sub-PRs in otia#484 without ever reading a check result, leaving three red feature branches behind. CI had found those failures within two minutes of each PR — the script just never looked.

## What was wrong

Four defects that only combine into silence:

| # | Defect | Effect |
|---|--------|--------|
| 1 | `"no checks reported"` treated as "this repo has no CI" | Merged during the few seconds before GitHub registers the check runs. otia#497: merged `12:44:01`, backend check started `12:44:04`, went red `12:44:56`. |
| 2 | `gh pr checks --required` filters on branch protection | A feature branch has none, so the set was empty on every sub-PR — the gate could only ever return SKIP. |
| 3 | Every non-zero `gh` exit fell into the transient-error branch | Exit 8 (pending) and exit 1 (failing) were indistinguishable from a network blip. Latent today, load-bearing the moment `--required` is dropped. |
| 4 | `gh pr create` was unconditional | The `CI_GATE_BLOCKED` retry loop in `implement-epic` died on "already exists" instead of re-running the gate. |

## What changed

- **Fail closed.** The gate merges only on positive evidence that every check is green. Anything else blocks.
- **Separate registration deadline.** `--ci-grace <secs>` (default 120) is how long checks may take to *appear*; `--ci-timeout` (default 900) is how long registered checks may stay *pending*. An empty set inside the grace window means "not yet", not "no CI". Grace expires → `CI_GATE: FAIL — no checks appeared after 120s`, no merge.
- **`--required` dropped.** All reported checks are awaited, protection or not.
- **Exit codes disambiguated.** Exit 8 → pending loop. Exit 1 → failing checks (JSON payload parsed) or a real `gh` error (payload does not parse) → retry once, then fail closed.
- **Idempotent PR creation.** The open PR for the branch is reused, so re-running with identical arguments re-runs the gate.
- `CI_GATE: SKIP` now occurs only via `--no-ci-wait` or `--no-merge`.

Why fail-closed rather than SKIP-after-grace: SKIP is the same fail-open assumption 120 seconds later. A workflow file with a syntax error, or a slow Actions queue, would still read as "this project has no CI".

## Two further fail-open paths found while verifying

Both found by verifying the implementation against its own premise, not by the original issue:

1. **Non-array JSON passed the payload guard.** `jq -r 'length'` also answers for objects, so a `{"message":"Not Found"}` body with exit 0 satisfied the numeric check. The subsequent `.[]` queries then errored (jq exit 5) — and since the gate runs inside `if ! wait_for_ci_gate`, `set -e` is suppressed for the entire call, so both name lists came back empty and the gate printed `CI_GATE: PASS` and **merged with zero green evidence**. Reproduced end-to-end before the fix. Guarded on `type == "array"`.
2. **`--ci-poll-interval 0` spun forever.** Every deadline counter advances by the poll interval, so neither `CI_TIMEOUT` nor `CI_GRACE` was ever reached — a hung gate hammering `gh`. Validated up front.

## Tests

`bin/test-git-push-pr-merge.sh` — **50/50 assertions passing**, `shellcheck` clean on both scripts.

The old suite passed 8 scenarios while the gate under test was a no-op, because the stub ignored `--required` and knew only exit 0 and 1. The stub now models real `gh`: `--required` returns an empty set with exit 0 on an unprotected branch, pending exits 8, failing exits 1, and `gh pr list` reports an existing PR.

- **Scenario 1 inverted** — `"no checks reported"` asserts FAIL and no merge, where it previously asserted SKIP and merge. That assertion *was* the bug.
- **New:** checks appearing late within grace (9), grace expiry (10), exit 8 as pending (11), PR reuse on re-run (12), non-array JSON (6c), zero poll interval (13).

Mutation-checked rather than assumed: disabling the exit-8 branch in a scratch copy turns scenario 11 red with `unexpectedly found 'unable to verify'` — the exact misreading AC 6 forbids. The scenario initially passed for the wrong reason (its stub went green on call 2, which the single transient retry also reaches), so the stub now exits 8 four times.

## Blast radius

- The `/implement` skill calls the script with `--no-merge` → gate skipped entirely, **unaffected** (scenario 8 asserts this).
- `implement-epic` is the only caller that reaches the gate. Its 3-attempt `CI_GATE_BLOCKED` recovery only actually works now that the create is idempotent.
- Expect epics to be slower (each sub-PR genuinely waits for CI, ~1-2 min) and ❌ to appear where a red branch used to merge quietly. That is the gate working, not a regression.
- **This repo has no CI workflows of its own.** If the script is ever run here *with* merge, `--no-ci-wait` is now required — noted in the README.

## Manual Review Needed

- **AC 9 — end-to-end verification against a real PR with a deliberately failing check.** Deferred by explicit decision: this repo has no CI workflows, so producing a genuinely failing check would mean adding and then removing a throwaway workflow plus a real PR. The stub harness covers the logic, but the real-`gh` surface — the exact exit codes and the `"no checks reported"` stderr wording that `grep -qi` matches — remains stub-verified only, modelled from `gh pr checks --help`. Worth confirming on the next real epic run.
