### PR TITLE
feat(hook): deny sed used as a file reader, pointing at Read

### DIFF
--- a/bin/hook-auto-approve-bash.py
+++ b/bin/hook-auto-approve-bash.py
@@ -285,6 +285,30 @@ def _is_safe_find_invocation(tokens):
     return not any(token in danger_flags for token in tokens)
 
 
+def is_sed_file_read(tokens):
+    """True for `sed -n 'X,Yp' <file>` and friends — sed used as a plain file
+    reader, which is Read with offset/limit written as a shell command.
+
+    Deliberately narrow. A real stream edit (-i, a substitution, reading from a
+    pipe) is NOT matched: those are legitimate shell work and must keep falling
+    through to a normal prompt rather than being denied."""
+    if not tokens or tokens[0] != "sed":
+        return False
+    if "-n" not in tokens and "--quiet" not in tokens and "--silent" not in tokens:
+        return False
+
+    operands = [t for t in tokens[1:] if not t.startswith("-")]
+    # Need both a script and at least one file operand; `sed -n 1,5p` alone
+    # reads stdin, so there is no file for Read to open instead.
+    if len(operands) < 2:
+        return False
+
+    # The script is the first operand. Match a line-range print: N p, N,M p,
+    # N,$ p — optionally with the whole thing wrapped in braces.
+    script = operands[0].strip("{} ")
+    return bool(re.fullmatch(r"\d+(,(\d+|\$))?\s*p", script))
+
+
 def is_segment_safe(segment_tokens):
     """A segment is safe if, after stripping cd/env prefixes, its first
     token is on ALLOWLIST or a ~/.claude/bin/ script — with no command
@@ -329,6 +353,20 @@ def is_segment_safe(segment_tokens):
     return True
 
 
+def command_has_sed_file_read(command):
+    """True if any segment of `command` uses sed as a file reader. False
+    (never raises) on unparseable input — the caller falls through."""
+    try:
+        segments = split_segments(command)
+    except ValueError:
+        return False
+
+    return any(
+        is_sed_file_read(strip_env_prefix(strip_cd_prefix(segment)))
+        for segment in segments
+    )
+
+
 def is_command_safe(command):
     """True if every segment of `command` is safe. False (never raises)
     on unparseable input — the caller falls through to the normal prompt."""
@@ -349,6 +387,23 @@ def main():
 
     command = payload.get("tool_input", {}).get("command", "")
     if not command:
+        return 0
+
+    # Deny wins over allow: a chain that is otherwise fully allowlisted is
+    # still denied when one of its segments reads a file through sed.
+    if command_has_sed_file_read(command):
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    "Hook: `sed -n 'X,Yp' <file>` is a file read. Use the Read "
+                    "tool with offset/limit instead — it is allowlisted, shows "
+                    "line numbers, and needs no permission prompt."
+                ),
+            }
+        }
+        print(json.dumps(output))
         return 0
 
     if is_command_safe(command):

--- a/bin/test-hook-auto-approve-bash.py
+++ b/bin/test-hook-auto-approve-bash.py
@@ -484,5 +484,91 @@ check(
     not hook.is_command_safe("cd /etc 2>/dev/null; echo hi"),
 )
 
+# --- sed as a file reader: deny with a hint pointing at Read ---
+# `sed -n 'X,Yp' <file>` is Read with offset/limit spelled as a shell command.
+# The global CLAUDE.md has forbidden it for a long time and it still showed up
+# in 30 sessions, so it is enforced here rather than documented again.
+
+check(
+    "sed-read: -n with a line-range p is a file read",
+    hook.is_sed_file_read(["sed", "-n", "250,262p", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: single-line form is a file read too",
+    hook.is_sed_file_read(["sed", "-n", "42p", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: $ as the range end is a file read",
+    hook.is_sed_file_read(["sed", "-n", "10,$p", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: quoted range (shlex strips the quotes) is a file read",
+    hook.is_sed_file_read(hook._tokenize("sed -n '250,262p' /tmp/x.py")),
+)
+
+# The deny is narrow ON PURPOSE: a real stream edit must stay promptable, not
+# be denied outright, or the hook starts blocking legitimate shell work.
+check(
+    "sed-read: in-place edit is NOT classified as a read",
+    not hook.is_sed_file_read(["sed", "-i", "s/a/b/", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: substitution without -n is NOT classified as a read",
+    not hook.is_sed_file_read(["sed", "s/a/b/", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: -n reading from a pipe (no file operand) is NOT a read of a file",
+    not hook.is_sed_file_read(["sed", "-n", "1,5p"]),
+)
+
+# These three are what makes the line-range regex load-bearing. Without them
+# the earlier guards (-n present, >=2 operands) already reject every negative
+# case, so replacing the regex with `return True` passes the whole suite — the
+# "an earlier guard swallows the test" pattern from shell-and-config-testing.md
+# §2. Verified by mutation: `return True` flips exactly these.
+check(
+    "sed-read: deletion script with -n is not a line-range print",
+    not hook.is_sed_file_read(["sed", "-n", "/foo/d", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: a printing substitution is an edit, not a line-range read",
+    not hook.is_sed_file_read(["sed", "-n", "s/a/b/p", "/tmp/x.py"]),
+)
+
+check(
+    "sed-read: line-count script with -n is not a line-range print",
+    not hook.is_sed_file_read(["sed", "-n", "$=", "/tmp/x.py"]),
+)
+
+# End-to-end: the hook must emit an explicit deny with an actionable reason.
+approved, reason, rc = run_hook("sed -n '250,262p' /tmp/x.py")
+check("sed-read: hook does not approve it", not approved)
+check(
+    "sed-read: hook denies with a Read hint",
+    reason is not None and "Read" in reason,
+)
+check("sed-read: hook still exits 0", rc == 0)
+
+# A denied sed anywhere in a chain denies the whole command.
+approved, reason, _ = run_hook("git status; sed -n '1,5p' /tmp/x.py")
+check("sed-read: denied inside a chain", not approved and reason is not None)
+
+# Unrelated commands keep their existing behaviour: allowed stays allowed,
+# and a non-allowlisted command stays a silent fall-through (no deny).
+approved, reason, _ = run_hook("git status")
+check("sed-read: unrelated allowed command still approved", approved)
+
+approved, reason, _ = run_hook("sed -i 's/a/b/' /tmp/x.py")
+check(
+    "sed-read: a real stream edit falls through to a prompt, not a deny",
+    not approved and reason is None,
+)
+
 print(f"\nResults: {passed} passed, {failed} failed")
 sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Wat

`sed -n 'X,Yp' <file>` is de Read-tool met offset/limit, geschreven als shellcommando. De globale CLAUDE.md verbiedt dat al lang, maar een frictiescan over 30 dagen vond nog **128 zulke aanroepen in 30 sessies**.

Per de code-review-regel — *"a convention violated more than once is a linter rule / test / pre-commit hook — not a line in the docs"* — is dit nu een hook in plaats van nog een regel documentatie.

## Hoe

De deny is bewust smal. Er moet aan drie voorwaarden tegelijk zijn voldaan:

1. `-n` aanwezig
2. het script is een regelbereik-print (`X,Yp`)
3. minstens één bestandsargument

Valt één daarvan weg, dan gedraagt het commando zich exact als voorheen. Een echte stream-edit (`-i`, een substitutie, invoer uit een pipe) valt dus door naar de normale prompt in plaats van geblokkeerd te worden.

Dit is het eerste weiger-pad van de hook; hij was daarvoor alleen allow-or-stay-silent. Niet-matchende commando's veranderen niet van gedrag.

## Tests

96 passed, 0 failed (was 80) — `python3 bin/test-hook-auto-approve-bash.py`

Mutatie-getest op kopieën in een scratchpad, zodat de geïnstalleerde hook nooit verzwakt werd. Vier mutaties, nul overlevers:

- het uitschakelen van de deny in `main()` wordt alleen gevangen door de end-to-end-tests
- het vervangen van de regelbereik-regex door `return True` wordt alleen gevangen door de drie negatieve cases die daarvoor zijn toegevoegd

Zonder die negatieve cases slikken de eerdere guards elke negatieve invoer en blijft de regex onbewezen — het "an earlier guard catches the test first"-patroon.
