### PR TITLE
docs(claude-md): document RTK as an optional, separately installed tool

### DIFF
--- a/claude-md/RTK.md
+++ b/claude-md/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (cuts up to 90% of bash output)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/claude-md/RTK.md
+++ b/claude-md/RTK.md
@@ -2,6 +2,29 @@
 
 **Usage**: Token-optimized CLI proxy (cuts up to 90% of bash output)
 
+## What RTK Is
+
+A CLI proxy that intercepts shell commands and compresses their output before it
+reaches the model's context. Single Rust binary, 100+ supported commands, <10ms
+overhead. Apache-2.0, https://github.com/rtk-ai/rtk
+
+| Operation | What RTK does to the output |
+|-----------|-----------------------------|
+| `ls` / `tree` | Tree format with file counts instead of one line per entry |
+| `cat` / `read` | Signatures and structure over full bodies |
+| `grep` / `rg` | Truncates long lines, groups matches by file |
+| `git status` | Compact stat format, grouped by state |
+| `git diff` | Reduced context, headers stripped |
+| `git log` | Hash, author and subject only |
+| `git add/commit/push` | Confirmation line instead of full progress output |
+| `pytest` / `npm test` / `cargo test` | Failures only, passing tests collapsed to a count |
+| `ruff check` | Grouped by rule and file |
+| `docker ps` | Essential fields only |
+
+The "up to 90%" figure is what RTK measures on the bash output it filters — it is
+not a 90% reduction of the total bill. Command output is one part of a request;
+the system prompt, conversation history and file reads are unaffected.
+
 ## Meta Commands (always use rtk directly)
 
 ```bash

--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -96,3 +96,13 @@ Werk aan een issue → branchnaam VERPLICHT `issue-<nummer>-<slug>`, waar `<slug
 - **Tmp-bestandsnamen: ALTIJD uniek per project + taak.** NOOIT generieke namen als `/tmp/commit-msg.txt` of `/tmp/pr-body.md` — er draaien vaak meerdere agents tegelijk, ook in verschillende projecten, en die overschrijven elkaars bestand. Schema: `/tmp/<project>-<doel>-<nr>.<ext>`, waarbij `<project>` de basename van de working directory is, lowercase, niet-alfanumerieke tekens vervangen door `-` (bv. `~/Projects/Acme-Webshop` → `acme-webshop`), en `<nr>` het issue- of PR-nummer. Voorbeelden: `/tmp/acme-webshop-commit-msg-42.txt`, `/tmp/acme-webshop-pr-body-42.md`, `/tmp/acme-webshop-issue-body-42.md`. Zonder issue/PR-nummer: gebruik een kort beschrijvend doel (`/tmp/acme-webshop-deploy-log.txt`).
 - Never use `python3 -c`, `sed`, or `awk` for file reading, writing, searching, or modifications. Use Grep/Read to find content, then Edit to replace. `python3 -c` is allowed for non-file operations (calculations, data transformations, etc.).
 - For batch operations on multiple issues, always use `~/.claude/bin/` scripts (e.g., `batch-issue-status.sh`, `batch-issue-view.sh`). Never use `for` loops or chained `&&` commands to repeat `gh` calls.
+
+<!--
+RTK (Rust Token Killer) — optional, install separately: https://github.com/rtk-ai/rtk
+  curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+  rtk init -g          # registers the `rtk hook claude` hook in ~/.claude/settings.json
+Without both steps the import below loads instructions for a tool that is not
+installed. Claude Code silently ignores a missing import, so RTK.md is safe to
+delete when RTK is not in use.
+-->
+@RTK.md


### PR DESCRIPTION
## Probleem

`claude-md/global.md` importeerde `@RTK.md`, maar dat bestand stond alleen in `~/.claude/` — buiten deze repo. Wie de toolkit kloont kreeg dus een import die nergens naar wees.

Claude Code negeert een ontbrekende import **stil**: geen foutmelding. RTK zou simpelweg niet geladen worden, zonder dat iets uitlegt waarom.

## Oplossing

**`claude-md/RTK.md`** — het bestand staat nu in de repo, zodat de import na een clone resolvet. Het bevat uitsluitend gebruiksdocumentatie; geen credentials, hostnamen of persoonlijke gegevens.

**Commentaar boven de import** — legt vast dat RTK optioneel is en apart geïnstalleerd moet worden, met beide stappen:

```bash
curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
rtk init -g
```

Die tweede stap was nergens gedocumenteerd en is makkelijk over het hoofd te zien. RTK werkt via een hook die `git status` herschrijft naar `rtk git status`; `rtk init -g` is wat die hook in `settings.json` registreert. Alleen de binary installeren laat de tool inert achter.

Upstream: https://github.com/rtk-ai/rtk

## Handmatige nazorg

`~/.claude/RTK.md` bestaat lokaal nog als losse kopie, niet als symlink naar de repo — de rest van deze toolkit volgt wél het symlink-patroon. Zolang dat zo blijft, kunnen de twee kopieën uit elkaar lopen. Herstellen:

```bash
rm ~/.claude/RTK.md
ln -s ~/Projects/claude-code-toolkit/claude-md/RTK.md ~/.claude/RTK.md
```
