### PR TITLE
docs: faalmodi van de git-wrapperscripts vastleggen

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `git-find-base-branch` | `git-find-base-branch` | Detect the base branch of the current branch |
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
-| `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents) |
-| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). Repos without CI need `--no-ci-wait` |
+| `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents). Can print `ok N files changed` without committing — see [failure modes](docs/git-script-failure-modes.md) |
+| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). Repos without CI need `--no-ci-wait`. Creates the PR itself, so `gh pr create` hooks do not fire — see [failure modes](docs/git-script-failure-modes.md) |
 
 ### Project audits
 

--- a/docs/git-script-failure-modes.md
+++ b/docs/git-script-failure-modes.md
@@ -1,0 +1,78 @@
+# Failure modes of the git wrapper scripts
+
+Two scripts in `bin/` can report what looks like success while doing nothing, or
+while quietly skipping a check you rely on. Both failures are readable from the
+output only if you know what to look for, so this page lists the signatures.
+
+## `git-commit.sh` — "ok N files changed" is not a commit
+
+The script can finish without creating a commit while its output still opens
+with a line that reads like progress:
+
+```
+ok 2 files changed, 183 insertions(+), 5 deletions(-)
+```
+
+That line comes from the `git add` before it. A real commit prints a
+`[branch abc1234] <message>` line; if that line is absent, nothing was
+committed.
+
+**Always verify with `git log --oneline -1`, never with the tail of the output.**
+The tail is the least reliable part: pre-commit prints per-hook results, so the
+last line is often `Passed` from an unrelated hook even when the commit failed.
+
+Five ways this happens:
+
+| # | Cause | Signature |
+|---|---|---|
+| 1 | Pre-commit rolled back its own auto-fixes | `[WARNING] Stashed changes conflicted with hook auto-fixes... Rolling back` |
+| 2 | Wrong repo (worktrees) | every hook `(no files to check) Skipped`, and a branch name you are not on |
+| 3 | cwd outside any repo | `fatal: not a git repository` |
+| 4 | A formatter rewrote the file you just staged | `git status --short` shows `MM` on the file afterwards |
+| 5 | A hook failed on its merits (lint) | `npm error command failed` above a later `Passed` line |
+
+Modes 1 and 4 are the same rollback with different triggers: a hook modifies a
+staged file in a way that conflicts with the stashed unstaged version. The fix
+is to stage the whole file (`git add <file>`) rather than partial changes, and
+to re-stage after a formatter rewrites it.
+
+Mode 5 is worth calling out because the lint command usually runs with
+`--max-warnings 0`. A **warning** then blocks the commit while the linter itself
+reports `0 errors, 1 warning`, which does not read as fatal. Run the linter
+directly to see the real message. Note that `cd <dir> && npx eslint` is
+unreliable for this — the working directory does not always take effect and
+eslint then silently reports nothing, which reads as clean. Prefer
+`npm --prefix <dir> exec -- eslint <file>`.
+
+For modes 2 and 3 the script already has the option you need: `--repo <path>`.
+It commits in the shell cwd, not wherever `git add -C <path>` pointed.
+
+## `git-push-pr-merge.sh` — bypasses `gh pr create` hooks
+
+The script creates the pull request itself. Any `PreToolUse` hook registered
+against `gh pr create` therefore never fires.
+
+This matters when a project gates PR bodies. PAM has
+`hook-check-agent-review.sh`, which requires a literal marker block from
+`.github/PULL_REQUEST_TEMPLATE.md` in the body of every agent-authored PR. Going
+through the wrapper skips that gate entirely: the PR is created, no hook
+complains, and the missing checklist is only noticed if someone reads the body.
+
+**Until the script validates this itself, check the body before you push** when
+the project has such a gate. The marker block is copied verbatim from the
+template and each box ticked against the actual diff — a heading with a similar
+name does not satisfy a parser that matches markers literally.
+
+Closing the gap in the script is deliberately not done here: it would apply to
+every project using the wrapper, including ones with no PR template, so it needs
+a guard on whether the template actually defines the markers. That is a separate
+change to make on purpose rather than as a side effect.
+
+## How to apply
+
+- After **every** `git-commit.sh`, run `git log --oneline -1`. Treat `ok N files
+  changed` as evidence of `git add` and nothing more.
+- When a commit does not appear, read the output for the five signatures above
+  before re-running. Re-running blind repeats the same failure.
+- When a project gates PR bodies, assemble and check the body before invoking
+  `git-push-pr-merge.sh` — the wrapper will not do it for you.


### PR DESCRIPTION
## Wat

Nieuwe doc `docs/git-script-failure-modes.md` met de faalmodi van de twee git-wrappers, plus verwijzingen vanuit de scripttabel in de README.

## Waarom

`git-commit.sh` kan eindigen zonder te committen terwijl de output opent met `ok N files changed` — die regel komt van de `git add` ervoor. De tail van de output is juist het minst betrouwbare stuk: pre-commit print per hook een resultaat, dus de laatste regel is vaak `Passed` van een hook die niets met de fout te maken heeft.

De doc verzamelt vijf triggers met hun signatuur:

| # | Oorzaak | Signatuur |
|---|---|---|
| 1 | Pre-commit rolt eigen auto-fixes terug | `Rolling back fixes...` |
| 2 | Verkeerde repo (worktrees) | alle hooks `Skipped`, vreemde branchnaam |
| 3 | cwd buiten een repo | `fatal: not a git repository` |
| 4 | Formatter herschrijft je gestagede bestand | `MM` in `git status --short` |
| 5 | Hook faalt inhoudelijk (lint) | `npm error command failed` bóven een latere `Passed` |

Modes 4 en 5 kwamen vandaag langs in PAM; 1 t/m 3 stonden al in projectlokale memory. Mode 5 is de venijnigste: de lint-stap draait vaak met `--max-warnings 0`, dus een **warning** blokkeert de commit terwijl de linter zelf `0 errors, 1 warning` meldt.

## Het tweede punt: een gat in `git-push-pr-merge.sh`

Het script maakt de PR zelf aan, dus `PreToolUse`-hooks die op `gh pr create` zijn geregistreerd vuren nooit. In PAM betekende dat concreet dat drie PR's langs `hook-check-agent-review.sh` kwamen zonder de verplichte checklist; dat viel pas op toen ik `gh pr create` een keer direct gebruikte.

**Bewust gedocumenteerd en niet in het script gerepareerd.** Een harde blokkade zou gelden voor elk project dat de wrapper gebruikt, inclusief projecten zonder PR-template — deze repo is daar zelf een voorbeeld van, die heeft er geen. Zo'n fix heeft een guard nodig op of het template de markers überhaupt definieert, en dat is een aparte beslissing in plaats van een bijvangst van een retro.

## Herkomst

Stond als projectlokale kennis in PAM's memory. De scripts zijn gedeeld, dus het generieke deel hoort hier; de PAM-memory houdt de projectspecifieke details en verwijst nu naar deze doc.

## Wijzigingen

- `docs/git-script-failure-modes.md` (nieuw)
- `README.md`: twee scriptregels verwijzen naar de doc

Alleen documentatie; geen script- of gedragswijziging.
