### PR TITLE
fix(bin): stop i18n-audit reporting pluralised keys as missing and unused

### DIFF
--- a/bin/i18n-audit.py
+++ b/bin/i18n-audit.py
@@ -259,18 +259,50 @@ def scan_source_files(
     return key_locations, dynamic_keys
 
 
+# CLDR plural categories, as i18next suffixes them. A key with a `count`
+# option is looked up as `<key>_<category>` at runtime, so the bare key never
+# appears in the locale file and a literal comparison reports it missing.
+PLURAL_SUFFIXES = ("zero", "one", "two", "few", "many", "other")
+
+
 def check_missing(
     used_keys: Set[str], locale_keys: Set[str]
 ) -> Set[str]:
-    """Find keys used in code but not in locale."""
-    return used_keys - locale_keys
+    """Find keys used in code but not in locale.
+
+    A pluralised key resolves through its CLDR suffixes rather than its bare
+    form: `t("photos.count", {count})` reads `photos.count_one` /
+    `photos.count_other` and never `photos.count` itself. Treating the bare key
+    as missing is a false positive, and one that cannot be silenced without
+    duplicating the key — so any suffixed variant satisfies the bare form.
+    """
+    pluralised = {
+        key[: -(len(suffix) + 1)]
+        for key in locale_keys
+        for suffix in PLURAL_SUFFIXES
+        if key.endswith(f"_{suffix}")
+    }
+    return used_keys - locale_keys - pluralised
 
 
 def check_unused(
     used_keys: Set[str], locale_keys: Set[str]
 ) -> Set[str]:
-    """Find keys in locale but not used in code."""
-    return locale_keys - used_keys
+    """Find keys in locale but not used in code.
+
+    The mirror of the plural problem in `check_missing`: the code calls the bare
+    key, so `<key>_one` and `<key>_other` never appear as "used" and every
+    pluralised entry would be reported as dead translation. Deleting those on
+    that advice breaks the feature at runtime.
+    """
+    return {
+        key
+        for key in locale_keys - used_keys
+        if not (
+            any(key.endswith(f"_{suffix}") for suffix in PLURAL_SUFFIXES)
+            and key.rsplit("_", 1)[0] in used_keys
+        )
+    }
 
 
 def check_consistency(


### PR DESCRIPTION
## Probleem

i18next zoekt een key met een `count`-optie op via zijn CLDR-suffix. `t("photos.count", {count})` leest dus `photos.count_one` of `photos.count_other`, en nooit `photos.count` zelf.

Een letterlijke set-vergelijking ging daar in **beide richtingen tegelijk** de mist in:

| Check | Meldde | Waarom fout |
|---|---|---|
| missing | `photos.count` | staat niet in het locale-bestand, want daar staan de suffixen |
| unused | `photos.count_one`, `photos.count_other` | staan niet in de broncode, want die roept de bare key aan |

De **unused-helft was de gevaarlijke**. Dat advies opvolgen betekent precies die vertalingen weggooien die de feature op runtime laadt, en de audit gaf geen enkele hint dat het om een meervoudsvorm ging. De missing-helft is alleen ruis, maar ruis die je niet kunt onderdrukken zonder de key te dupliceren.

## Oplossing

- `check_missing` accepteert elke CLDR-suffixvariant als dekking voor de bare vorm
- `check_unused` behoudt een gesuffixte key wanneer zijn bare vorm wél in de broncode voorkomt

De suffixen (`zero`, `one`, `two`, `few`, `many`, `other`) staan als constante `PLURAL_SUFFIXES` bovenaan in plaats van als losse literals.

## Verificatie

Getest tegen een fixture met drie gevallen: een meervoudskey mét count, een echt ontbrekende key, en een echt dode meervoudsvorm.

| | Missing | Unused |
|---|---|---|
| Voor | 2 | 4 |
| Na | **1** | **2** |

De false positives zijn weg; `truly.missing` en `orphan.removed_*` worden nog steeds gemeld. De check verliest dus geen echte bevindingen.

## Kanttekening

Er is **geen testbestand** voor `i18n-audit.py` in deze repo, dus bovenstaande verificatie is handmatig gedaan met een wegwerp-fixture en is niet geborgd tegen regressie. Andere scripts hier hebben die dekking wel (`test-hook-auto-approve-bash.py`, `test-git-push-pr-merge.sh`). Een `bin/test-i18n-audit.py` zou dit gat dichten — buiten scope van deze fix, maar het noemen waard.
