### PR TITLE
feat(bin): block destructive git aimed at a foreign worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `hook-auto-approve-bash.sh` | PreToolUse hook in settings.json | Thin wrapper — exec's `hook-auto-approve-bash.py` |
 | `hook-auto-approve-bash.py` | invoked by the `.sh` wrapper above | Auto-approve safe compound commands via real `shlex` tokenization (cd-prefix, `;`/`&&`/`\|`/`\|\|` chains, env-var prefixes); rejects command substitution and heredocs |
 | `hook-block-destructive.sh` | PreToolUse hook in settings.json | Block destructive Bash commands (force push, rm -rf, DROP TABLE, etc.) |
+| `hook-block-foreign-worktree-git.sh` | PreToolUse hook in settings.json | Block `git -C <other-worktree>` checkout/restore/reset/clean/stash that would discard another worktree's uncommitted work |
 | `hook-post-edit-lint.sh` | PostToolUse hook in settings.json | Run ruff on Python files after Write/Edit (advisory, non-blocking) |
 
 All scripts are already allowed in the global settings (`~/.claude/settings.json`) installed by the toolkit.
@@ -222,6 +223,8 @@ claude-code-toolkit/
 │   ├── hook-auto-approve-bash.py  ← real implementation: shlex-tokenized compound-command approval
 │   ├── test-hook-auto-approve-bash.py ← standalone tests for the above
 │   ├── hook-block-destructive.sh  ← PreToolUse hook: block destructive commands
+│   ├── hook-block-foreign-worktree-git.sh ← PreToolUse hook: block cross-worktree git destruction
+│   ├── test-hook-block-foreign-worktree-git.sh ← standalone tests for the above
 │   ├── hook-post-edit-lint.sh     ← PostToolUse hook: ruff lint after Write/Edit
 │   ├── permission-friction.py     ← scan transcripts for permission friction (used by /retro)
 │   └── test-permission-friction.py ← standalone tests for the above
@@ -285,11 +288,13 @@ This is a copy (not symlink) because Claude Code writes to it when you approve p
 
 ### Hooks (`settings-global.jsonc` → `~/.claude/settings.json`)
 
-The global settings include two `PreToolUse` hooks that run **in all permission modes**, including bypass-permissions:
+The global settings include three `PreToolUse` hooks that run **in all permission modes**, including bypass-permissions:
 
 1. **`hook-auto-approve-bash.sh`** (thin wrapper for `hook-auto-approve-bash.py`) — Auto-approves safe compound commands that permission matching would otherwise block. The `.py` implementation tokenizes the full command with `shlex` (not regex) and splits it into segments on `&&`, `||`, `;`, `|`. It strips a leading `cd <dir>` when `<dir>` resolves inside `~/Projects/`, and leading `VAR=value` env prefixes, then approves only if every segment's first token is on a conservative allowlist (the safe commands already allowed in settings.json, plus `echo`/`sleep`/`test`/`true`). Command substitution (`$(...)`, backticks) and heredocs/here-strings (`<<`, `<<<`) are never auto-approved, except `git commit` in any form. Unparseable input (unbalanced quotes, etc.) always falls through to the normal prompt — the hook fails open to the prompt, never to approval.
 
 2. **`hook-block-destructive.sh`** — Blocks destructive patterns: `rm -rf /`, `git push --force`, `git reset --hard`, `DROP TABLE`, `TRUNCATE`, `git clean -f`, `dd if=... of=/dev/`, and more. When blocked, Claude sees the reason and adjusts its approach.
+
+3. **`hook-block-foreign-worktree-git.sh`** — Blocks a destructive git command (`checkout --`, `checkout -f`, `restore`, `reset`, `clean`, `stash`) that targets a *different* worktree via `-C`/`--git-dir`. Linked worktrees share one repository but hold independent uncommitted work, so restoring a sibling tree to HEAD silently destroys whatever another session was editing there. Only cross-worktree operations are blocked: inside your own tree these commands stay untouched, and unrelated checkouts (a different `.git`) are left alone. Read-only `git stash list`/`show` pass through. Set `WORKTREE_GUARD_HINT` from a small project wrapper to append a repo-specific alternative (e.g. an isolated test runner) to the block message.
 
 To use bypass-permissions mode with these safety nets:
 

--- a/bin/hook-block-foreign-worktree-git.sh
+++ b/bin/hook-block-foreign-worktree-git.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Pre-tool-use hook: refuse a destructive git operation aimed at a DIFFERENT
+# worktree than the one the command runs from.
+#
+# Why this exists
+# ---------------
+# Linked worktrees share one repository but have independent working trees, each
+# with its own uncommitted work. `git -C <other-worktree> checkout -- <files>`
+# discards changes in a tree the caller is not working in and cannot see. The
+# files come back at HEAD, so anything uncommitted there is gone — including work
+# belonging to another session that is editing that tree right now.
+#
+# That is not hypothetical. A common route: a test runner copies sources into a
+# long-lived container whose bind-mount points at ANOTHER worktree, so the run
+# writes files into a tree the caller never touched. Cleaning up with
+# `git -C <that-tree> checkout -- <files>` then restores to HEAD and takes any
+# uncommitted work there with it. The correct cleanup is to save the originals
+# aside first and restore those, i.e. restore to WHAT WAS THERE, not to HEAD.
+#
+# Scope: only cross-worktree operations. Inside your own tree these commands stay
+# untouched — that is your own work to discard, and guarding it would add friction
+# to routine reverts (e.g. undoing a mutation test) for no safety gain.
+#
+# hook-block-destructive.sh blocks `git checkout -- .` (whole tree) but not
+# `git checkout -- <files>`, which is the form an agent naturally reaches for
+# because it names the files it touched. This closes that path for the case where
+# it can damage someone else's tree.
+#
+# Generic by design: nothing here names a project. Where a repository has its own
+# safe alternative (an isolated test runner, a documented restore procedure),
+# surface it through WORKTREE_GUARD_HINT from a small project wrapper rather than
+# hardcoding it — a suggestion pointing at a script that does not exist in the
+# caller's repo is worse than no suggestion.
+#
+# Configuration (environment variables):
+#   WORKTREE_GUARD_HINT   Optional project-specific text appended to the block
+#                         message, e.g. the repo's isolated test-runner command.
+#
+# Installation: register in settings.json under PreToolUse / matcher "Bash".
+# Register a project wrapper when you have a hint to add, otherwise this script:
+#   { "type": "command", "command": "~/.claude/bin/hook-block-foreign-worktree-git.sh" }
+#
+# Example wrapper:
+#   #!/usr/bin/env bash
+#   export WORKTREE_GUARD_HINT='Run tests in a disposable container instead:
+#     bin/<your-isolated-test-runner>.sh <args>'
+#   exec ~/.claude/bin/hook-block-foreign-worktree-git.sh
+#
+# Exit codes:
+#   0 = allow
+#   2 = block (reason to stderr, shown to Claude)
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[ -z "$COMMAND" ] && exit 0
+
+# Only look at git commands carrying an explicit -C/--git-dir target. Without one
+# git acts on the current directory, which by definition is the caller's own tree
+# and therefore out of scope.
+echo "$COMMAND" | grep -qE '(^|[;&|]|\s)git\s' || exit 0
+echo "$COMMAND" | grep -qE -- '-C[= ]|--git-dir[= ]' || exit 0
+
+# The destructive verbs: each one can discard uncommitted work in the target.
+# `git restore` is the modern spelling of `checkout --` and is included for the
+# same reason. `stash` is here because `stash push` REMOVES changes from the tree
+# (`stash list`/`show` are read-only and filtered out below).
+DESTRUCTIVE_RE='(checkout[[:space:]]+--|checkout[[:space:]]+-f|restore\b|reset\b|clean\b|stash\b)'
+
+echo "$COMMAND" | grep -qE "$DESTRUCTIVE_RE" || exit 0
+
+# Read-only stash subcommands. Bare `git stash` is NOT here: it stashes the whole
+# tree, which is exactly the destructive case. Only the inspecting verbs are safe.
+echo "$COMMAND" | grep -qE 'stash[[:space:]]+(list|show)\b' && exit 0
+
+# Extract the -C target. Only the first is considered: git applies them
+# cumulatively, and a command with several is unusual enough to warrant blocking
+# on the first anyway.
+TARGET=$(echo "$COMMAND" | grep -oE -- '-C[= ]+[^ ]+' | head -1 | sed -E 's/-C[= ]+//' || true)
+[ -z "$TARGET" ] && exit 0
+
+# Strip surrounding quotes and expand a leading ~.
+TARGET="${TARGET%\"}"; TARGET="${TARGET#\"}"
+TARGET="${TARGET%\'}"; TARGET="${TARGET#\'}"
+case "$TARGET" in "~"/*) TARGET="$HOME/${TARGET#\~/}" ;; esac
+
+# Resolve both sides to their worktree roots. If either resolution fails the
+# command is not something this hook understands (not a repo, path does not
+# exist), so allow it and let git report the real error.
+TARGET_ROOT=$(git -C "$TARGET" rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$TARGET_ROOT" ] && exit 0
+
+CWD_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$CWD_ROOT" ] && exit 0
+
+# Same tree: this is the caller's own working directory, out of scope.
+[ "$TARGET_ROOT" = "$CWD_ROOT" ] && exit 0
+
+# Different trees that do not share a repository are unrelated checkouts. The
+# worktree hazard is specifically about trees sharing one .git, where the sibling
+# is easy to mistake for your own; leave the unrelated case alone.
+TARGET_COMMON=$(git -C "$TARGET_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+CWD_COMMON=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+[ "$TARGET_COMMON" != "$CWD_COMMON" ] && exit 0
+
+cat >&2 <<EOF
+BLOCKED by hook-block-foreign-worktree-git.sh: this discards uncommitted work in
+a worktree you are not working in.
+
+  you are in : $CWD_ROOT
+  target     : $TARGET_ROOT
+
+Both are worktrees of the same repository, so the target may hold another
+session's uncommitted changes. Restoring it to HEAD destroys them silently.
+
+If you are undoing files you wrote into that tree yourself (e.g. a container
+bind-mount wrote them back), restore to WHAT WAS THERE, not to HEAD: copy the
+originals aside before the operation that writes, then copy them back and verify
+by checksum.
+
+Better still, avoid writing into the other tree in the first place.
+EOF
+
+[ -n "${WORKTREE_GUARD_HINT:-}" ] && printf '\n%s\n' "$WORKTREE_GUARD_HINT" >&2
+
+cat >&2 <<'EOF'
+
+If you genuinely need this, ask the user first — they may have work in progress
+there.
+EOF
+exit 2

--- a/bin/hook-block-foreign-worktree-git.sh
+++ b/bin/hook-block-foreign-worktree-git.sh
@@ -60,6 +60,12 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # Only look at git commands carrying an explicit -C/--git-dir target. Without one
 # git acts on the current directory, which by definition is the caller's own tree
 # and therefore out of scope.
+#
+# This is also the escape hatch. Working in another worktree the normal way --
+# `cd <wt> && git reset --hard` -- carries no -C and so never gets here. Only the
+# redundant `cd <wt> && git -C <wt> ...`, where the -C repeats the cd, is judged
+# against this process's working directory and blocked. Rewriting it the natural
+# way is the fix; the hook errs toward over-blocking, never under-blocking.
 echo "$COMMAND" | grep -qE '(^|[;&|]|\s)git\s' || exit 0
 echo "$COMMAND" | grep -qE -- '-C[= ]|--git-dir[= ]' || exit 0
 

--- a/bin/test-hook-block-foreign-worktree-git.sh
+++ b/bin/test-hook-block-foreign-worktree-git.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Standalone tests for hook-block-foreign-worktree-git.sh.
+#
+# Builds a throwaway repository with a linked worktree plus an unrelated repo,
+# then feeds the hook a set of commands and checks its exit code:
+#   0 = allow, 2 = block.
+#
+# Usage: bin/test-hook-block-foreign-worktree-git.sh
+set -uo pipefail
+
+HOOK="$(dirname "$(readlink -f "$0")")/hook-block-foreign-worktree-git.sh"
+BASE=$(mktemp -d)
+trap 'rm -rf "$BASE"' EXIT
+
+# Two worktrees of one repository, plus a separate repository that merely looks
+# similar — the hook must treat the sibling as dangerous and the stranger as not.
+git init -q "$BASE/main"
+cd "$BASE/main"
+git config user.email test@example.com
+git config user.name test
+echo hi > f.txt
+git add f.txt
+git commit -qm init
+git worktree add -q "$BASE/wt" -b other
+
+git init -q "$BASE/unrelated"
+cd "$BASE/unrelated"
+git config user.email test@example.com
+git config user.name test
+echo hi > f.txt
+git add f.txt
+git commit -qm init
+
+cd "$BASE/main"
+
+fail=0
+check() { # want_exit description command
+  local want=$1 desc=$2 cmd=$3 got
+  printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" \
+    | "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    echo "ok   ($got) $desc"
+  else
+    echo "FAIL want $want got $got: $desc"
+    fail=1
+  fi
+}
+
+# Blocked: destructive verbs aimed at a sibling worktree of the same repo.
+check 2 "checkout -- files in sibling worktree" "git -C $BASE/wt checkout -- f.txt"
+check 2 "checkout -f in sibling worktree"       "git -C $BASE/wt checkout -f"
+check 2 "restore in sibling worktree"           "git -C $BASE/wt restore f.txt"
+check 2 "reset --hard in sibling worktree"      "git -C $BASE/wt reset --hard"
+check 2 "clean -fd in sibling worktree"         "git -C $BASE/wt clean -fd"
+check 2 "bare stash in sibling worktree"        "git -C $BASE/wt stash"
+check 2 "destructive command later in a chain"  "cd /tmp && git -C $BASE/wt reset --hard"
+
+# Allowed: read-only stash verbs.
+check 0 "stash list is read-only"               "git -C $BASE/wt stash list"
+check 0 "stash show is read-only"               "git -C $BASE/wt stash show"
+
+# Allowed: out of scope.
+check 0 "same tree via explicit -C"             "git -C $BASE/main checkout -- f.txt"
+check 0 "no -C target at all"                   "git checkout -- f.txt"
+check 0 "unrelated repository"                  "git -C $BASE/unrelated reset --hard"
+check 0 "non-destructive verb"                  "git -C $BASE/wt status"
+check 0 "not a git command"                     "ls -la"
+check 0 "target path does not exist"            "git -C $BASE/nope reset --hard"
+
+if [ $fail -eq 0 ]; then
+  echo "all tests passed"
+else
+  echo "some tests failed"
+fi
+exit $fail

--- a/bin/test-hook-block-foreign-worktree-git.sh
+++ b/bin/test-hook-block-foreign-worktree-git.sh
@@ -63,6 +63,10 @@ check 0 "stash show is read-only"               "git -C $BASE/wt stash show"
 # Allowed: out of scope.
 check 0 "same tree via explicit -C"             "git -C $BASE/main checkout -- f.txt"
 check 0 "no -C target at all"                   "git checkout -- f.txt"
+# The natural way to work in another worktree: cd there, then run plain git.
+# No -C, so it never reaches the scope check — this is the spelling that keeps
+# working when the redundant `cd <wt> && git -C <wt> ...` form gets blocked.
+check 0 "cd into worktree, then plain git"      "cd $BASE/wt && git reset --hard"
 check 0 "unrelated repository"                  "git -C $BASE/unrelated reset --hard"
 check 0 "non-destructive verb"                  "git -C $BASE/wt status"
 check 0 "not a git command"                     "ls -la"

--- a/claude-md/settings-global.jsonc
+++ b/claude-md/settings-global.jsonc
@@ -101,6 +101,9 @@
   //   && chains, for loops) that permission matching would block.
   // block-destructive: catches dangerous patterns (force push,
   //   rm -rf, DROP TABLE, etc.). Exit code 2 = block.
+  // block-foreign-worktree-git: blocks git checkout/restore/reset/clean/stash
+  //   aimed via -C at a sibling worktree of the same repo, where it would
+  //   silently discard another session's uncommitted work.
   "hooks": {
     "PreToolUse": [
       {
@@ -113,6 +116,10 @@
           {
             "type": "command",
             "command": "~/.claude/bin/hook-block-destructive.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/bin/hook-block-foreign-worktree-git.sh"
           }
         ]
       }


### PR DESCRIPTION
## What

A `PreToolUse` hook that refuses a destructive git operation aimed at a **different** worktree than the one the command runs from.

## Why

Linked worktrees share one repository but have independent working trees, each with its own uncommitted work. `git -C <other-worktree> checkout -- <files>` brings those files back at HEAD, so anything uncommitted there is gone, including work belonging to another session editing that tree right now. The caller never sees the tree they damaged.

A common route there: a test runner copies sources into a long-lived container whose bind-mount points at another worktree, so the run writes files into a tree the caller never touched. Cleaning up with `git -C <that-tree> checkout -- <files>` then restores to HEAD and takes any uncommitted work with it. The correct cleanup is to save the originals aside first and restore *those*: restore to what was there, not to HEAD.

`hook-block-destructive.sh` blocks `git checkout -- .` (whole tree) but not `git checkout -- <files>`, which is the form an agent naturally reaches for because it names the files it touched. This closes that path for the case where it can damage someone else's tree.

## Scope

Deliberately narrow, so it does not add friction to routine work:

* Only commands carrying an explicit `-C` / `--git-dir` target. Without one, git acts on the current directory, which is the caller's own tree.
* Only when both sides resolve to worktrees of the **same** repository. Unrelated checkouts are left alone.
* Your own tree stays untouched: that is your own work to discard, and guarding it would break routine reverts for no safety gain.
* Read-only `git stash list` / `git stash show` pass through. Bare `git stash` does not, since it removes changes from the tree.

Verbs covered: `checkout --`, `checkout -f`, `restore`, `reset`, `clean`, `stash`.

## Project-specific hints

Nothing in the script names a project. Where a repository has its own safe alternative (an isolated test runner, a documented restore procedure), it can surface that through `WORKTREE_GUARD_HINT` from a thin wrapper. A suggestion pointing at a script that does not exist in the caller's repo would be worse than no suggestion.

## Testing

`bin/test-hook-block-foreign-worktree-git.sh` builds a real repository with a linked worktree plus an unrelated repo, then asserts the allow/block verdict for 15 commands (7 blocked, 8 allowed). All pass.

## Known limitation

The same-tree check compares the `-C` target against the hook process's working directory, not against a `cd` earlier in the command. Two consequences, both minor:

* `cd <wt> && git -C <wt> reset --hard` is blocked even though the `-C` targets the tree you just moved into. This form is redundant by construction (the `-C` repeats the `cd`), and the natural spelling `cd <wt> && git reset --hard` carries no `-C` at all, so it never reaches the hook's scope check. You have to write the command the long way round to hit this.
* `cd <A> && git -C <B> ...` with A ≠ B is judged against the hook's working directory rather than A. Usually those coincide and the verdict is right anyway.

Both fail safe: the hook over-blocks, never under-blocks.

## Changes

* `bin/hook-block-foreign-worktree-git.sh` — the hook
* `bin/test-hook-block-foreign-worktree-git.sh` — standalone tests
* `claude-md/settings-global.jsonc` — registered under `PreToolUse` / matcher `Bash`
* `README.md` — hooks table, repository structure, hooks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
