### PR TITLE
fix(bin): stop i18n-audit reporting keys under a dynamic prefix as unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 
 | Script | Usage | Description |
 |--------|-------|-------------|
-| `i18n-audit.py` | `i18n-audit.py [project-dir]` | Audit i18n translation keys (missing, unused, cross-locale) |
+| `i18n-audit.py` | `i18n-audit.py [project-dir]` | Audit i18n translation keys (missing, unused, undeterminable, cross-locale) |
 | `env-audit.sh` | `env-audit.sh [project-dir]` | Audit .env vs .env.example sync, empty values, secrets in git |
 | `deps-audit.sh` | `deps-audit.sh [project-dir]` | Audit npm/pip dependencies for known vulnerabilities |
 | `docker-audit.sh` | `docker-audit.sh [project-dir]` | Audit Docker config (unpinned images, health checks, secrets) |

--- a/bin/i18n-audit.py
+++ b/bin/i18n-audit.py
@@ -84,6 +84,37 @@ def is_key_shaped(candidate: str) -> bool:
     return bool(KEY_SHAPE_PATTERN.match(candidate))
 
 
+def extract_static_prefix(pattern: str) -> Optional[str]:
+    """The literal namespace a dynamic key reaches, or None if there is none.
+
+    `admin.users.roles.${role}` resolves at runtime to some key under
+    `admin.users.roles.`, so the prefix is everything up to the first `${`.
+    Anything after it is unknowable and discarded, including further segments.
+
+    Returns None when the prefix would not name a namespace: a pattern starting
+    with the interpolation has no static part, and one whose interpolation does
+    not follow a dot (`errorCode${code}`) interpolates inside a segment rather
+    than choosing between segments. Both would otherwise yield a prefix that
+    matches far more keys than the call site can actually reach.
+    """
+    static = pattern.split("${", 1)[0]
+    if ":" in static:
+        static = static.split(":", 1)[1]
+    if not static.endswith("."):
+        return None
+    return static
+
+
+def dynamic_prefixes(dynamic_keys: List[Tuple[str, str, int]]) -> Set[str]:
+    """The set of static prefixes over all detected dynamic call sites."""
+    prefixes = set()
+    for pattern, _filepath, _lineno in dynamic_keys:
+        prefix = extract_static_prefix(pattern)
+        if prefix:
+            prefixes.add(prefix)
+    return prefixes
+
+
 @dataclass
 class ScanResult:
     """What a source scan found.

--- a/bin/i18n-audit.py
+++ b/bin/i18n-audit.py
@@ -443,8 +443,14 @@ def format_plain_text(
     dynamic_keys: List[Tuple[str, str, int]],
     checks: List[str],
     project_root: str,
+    dynamic_limit: int = 0,
 ) -> str:
-    """Format results as plain text."""
+    """Format results as plain text.
+
+    `dynamic_limit` caps the dynamic-key listing; 0 shows all of them. Truncating
+    by default would leave the reader unable to check by hand which prefixes
+    caused keys to be filtered out of the unused list.
+    """
     lines = []
     lines.append("i18n Audit Report")
     lines.append("=" * 50)
@@ -549,11 +555,12 @@ def format_plain_text(
         lines.append(f"── Dynamic Keys ({len(dynamic_keys)}) " + "─" * 27)
         lines.append("Keys using template literals (cannot audit statically):")
         lines.append("")
-        for pattern, filepath, lineno in dynamic_keys[:10]:
+        shown = dynamic_keys if dynamic_limit <= 0 else dynamic_keys[:dynamic_limit]
+        for pattern, filepath, lineno in shown:
             rel_path = os.path.relpath(filepath, project_root)
             lines.append(f"  `{pattern}`  {rel_path}:{lineno}")
-        if len(dynamic_keys) > 10:
-            lines.append(f"  ... and {len(dynamic_keys) - 10} more")
+        if len(shown) < len(dynamic_keys):
+            lines.append(f"  ... and {len(dynamic_keys) - len(shown)} more")
         lines.append("")
 
     lines.append("── Summary " + "─" * 39)
@@ -715,6 +722,14 @@ Examples:
         help="Comma-separated directories to skip (added to defaults)",
     )
     parser.add_argument(
+        "--dynamic-limit",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Max dynamic keys to list in the text report (default: 0 = all). "
+             "Ignored with --json, which is always complete.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         dest="json_output",
@@ -853,6 +868,7 @@ Examples:
         print(format_plain_text(
             config, missing, unused, undeterminable, consistency,
             key_locations, dynamic_keys, checks, str(project_root),
+            args.dynamic_limit,
         ))
 
     # Exit code

--- a/bin/i18n-audit.py
+++ b/bin/i18n-audit.py
@@ -412,6 +412,16 @@ def check_consistency(
     return result
 
 
+def _covering_prefix(key: str, prefixes: Set[str]) -> Optional[str]:
+    """The dynamic prefix that makes this key unresolvable.
+
+    Longest match wins, so a key under both `admin.` and `admin.users.` is
+    attributed to the call site that actually reaches it.
+    """
+    matches = [prefix for prefix in prefixes if key.startswith(prefix)]
+    return max(matches, key=len) if matches else None
+
+
 def group_by_prefix(keys: Set[str]) -> Dict[str, List[str]]:
     """Group keys by their first dot-segment."""
     groups: Dict[str, List[str]] = {}
@@ -427,6 +437,7 @@ def format_plain_text(
     config: dict,
     missing: Set[str],
     unused: Set[str],
+    undeterminable: Set[str],
     consistency: Dict[str, Set[str]],
     key_locations: Dict[str, List[Tuple[str, int]]],
     dynamic_keys: List[Tuple[str, str, int]],
@@ -472,6 +483,15 @@ def format_plain_text(
 
     if "unused" in checks or "all" in checks:
         lines.append(f"── Unused Keys ({len(unused)}) " + "─" * 30)
+        if dynamic_keys:
+            lines.append(
+                f"WARNING: {len(dynamic_keys)} dynamic key(s) detected — this list "
+                "cannot be fully reliable."
+            )
+            lines.append(
+                "         Verify a key is truly dead before deleting it."
+            )
+            lines.append("")
         if unused:
             lines.append("Keys in reference locale but not found in source code:")
             lines.append("")
@@ -479,12 +499,30 @@ def format_plain_text(
                 lines.append(f"  {prefix}:")
                 for key in keys:
                     lines.append(f"    {key}")
-            if dynamic_keys:
-                lines.append("")
-                lines.append(f"  Note: {len(dynamic_keys)} dynamic key(s) detected (cannot verify statically)")
             total_issues += len(unused)
         else:
             lines.append("  No unused keys found.")
+        lines.append("")
+
+        lines.append(f"── Undeterminable Keys ({len(undeterminable)}) " + "─" * 20)
+        if undeterminable:
+            lines.append(
+                "Unreferenced keys that a dynamic call site can still reach. "
+                "Not dead — not counted as issues."
+            )
+            lines.append("")
+            prefixes = dynamic_prefixes(dynamic_keys)
+            counts: Dict[str, int] = {}
+            for key in undeterminable:
+                covering = _covering_prefix(key, prefixes)
+                if covering:
+                    counts[covering] = counts.get(covering, 0) + 1
+            for prefix in sorted(counts):
+                lines.append(f"  {prefix}*  ({counts[prefix]} key(s))")
+            lines.append("")
+            lines.append("  Use --json for the full key list.")
+        else:
+            lines.append("  None.")
         lines.append("")
 
     if "consistency" in checks or "all" in checks:
@@ -524,6 +562,7 @@ def format_plain_text(
         parts.append(f"Missing: {len(missing)}")
     if "unused" in checks or "all" in checks:
         parts.append(f"Unused: {len(unused)}")
+        parts.append(f"Undeterminable: {len(undeterminable)}")
     if "consistency" in checks or "all" in checks:
         consistency_total = sum(len(v) for v in consistency.values())
         parts.append(f"Inconsistent: {consistency_total}")
@@ -541,6 +580,7 @@ def format_json_output(
     config: dict,
     missing: Set[str],
     unused: Set[str],
+    undeterminable: Set[str],
     consistency: Dict[str, Set[str]],
     key_locations: Dict[str, List[Tuple[str, int]]],
     dynamic_keys: List[Tuple[str, str, int]],
@@ -564,6 +604,10 @@ def format_json_output(
 
     if "unused" in checks or "all" in checks:
         result["unused"] = [{"key": key} for key in sorted(unused)]
+        result["undeterminable"] = [
+            {"key": key, "prefix": _covering_prefix(key, dynamic_prefixes(dynamic_keys))}
+            for key in sorted(undeterminable)
+        ]
 
     if "consistency" in checks or "all" in checks:
         result["consistency"] = {
@@ -594,6 +638,9 @@ def format_json_output(
             sum(len(v) for v in consistency.values())
             if ("consistency" in checks or "all" in checks)
             else None
+        ),
+        "undeterminableCount": (
+            len(undeterminable) if ("unused" in checks or "all" in checks) else None
         ),
         "dynamicKeyCount": len(dynamic_keys),
         "totalIssues": total_issues,
@@ -799,12 +846,12 @@ Examples:
     # Output
     if args.json_output:
         print(format_json_output(
-            config, missing, unused, consistency,
+            config, missing, unused, undeterminable, consistency,
             key_locations, dynamic_keys, checks, str(project_root),
         ))
     else:
         print(format_plain_text(
-            config, missing, unused, consistency,
+            config, missing, unused, undeterminable, consistency,
             key_locations, dynamic_keys, checks, str(project_root),
         ))
 

--- a/bin/i18n-audit.py
+++ b/bin/i18n-audit.py
@@ -378,6 +378,25 @@ def check_unused(
     }
 
 
+def split_undeterminable(
+    unused: Set[str], prefixes: Set[str]
+) -> Tuple[Set[str], Set[str]]:
+    """Split unused keys into genuinely dead ones and unresolvable ones.
+
+    A key under a prefix the code interpolates into is reachable at runtime; the
+    audit simply cannot say from which call. Reporting it alongside dead keys is
+    what makes the unused list unsafe to act on, so it becomes its own bucket.
+
+    Prefixes end in a dot, so matching is on the segment boundary: the
+    `admin.users.` prefix covers `admin.users.roles.owner` but not the unrelated
+    sibling `admin.usersOverview`.
+    """
+    undeterminable = {
+        key for key in unused if any(key.startswith(prefix) for prefix in prefixes)
+    }
+    return unused - undeterminable, undeterminable
+
+
 def check_consistency(
     locales: Dict[str, Dict[str, str]], reference: str
 ) -> Dict[str, Set[str]]:
@@ -757,6 +776,11 @@ Examples:
         if args.check in ("consistency", "all")
         else {}
     )
+
+    # Dynamic call sites are collected regardless of --check, so the unused list
+    # is filtered the same way whichever checks are requested.
+    prefixes = dynamic_prefixes(dynamic_keys)
+    unused, undeterminable = split_undeterminable(unused, prefixes)
 
     # Build config info
     rel_locale_dir = os.path.relpath(locale_dir, project_root)

--- a/bin/test-i18n-audit.py
+++ b/bin/test-i18n-audit.py
@@ -206,6 +206,143 @@ check(
 )
 
 
+# --- end-to-end: a dynamic prefix must not produce issues or a failing exit ---
+
+
+def run_audit(locale: dict, sources: dict, *extra_args):
+    """Run the audit as a subprocess over a throwaway project."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        locale_dir = root / "src" / "i18n" / "locales"
+        locale_dir.mkdir(parents=True)
+        (locale_dir / "nl.json").write_text(
+            json.dumps(locale, ensure_ascii=False), encoding="utf-8"
+        )
+        for name, body in sources.items():
+            path = root / "src" / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), str(root), *extra_args],
+            capture_output=True,
+            text=True,
+        )
+
+
+DYNAMIC_LOCALE = {
+    "admin": {
+        "users": {
+            "roles": {
+                "moderator": "Moderator",
+                "owner": "Eigenaar",
+                "guest": "Gast",
+            },
+            "title": "Gebruikersbeheer",
+        }
+    }
+}
+
+DYNAMIC_SOURCE = {
+    "RoleBadge.tsx": (
+        "import { useTranslation } from 'react-i18next';\n"
+        "export function RoleBadge({ role }: { role: string }) {\n"
+        "  const { t } = useTranslation();\n"
+        "  return <span>{t(`admin.users.roles.${role}`)}</span>;\n"
+        "}\n"
+    ),
+    "UsersPage.tsx": (
+        "import { useTranslation } from 'react-i18next';\n"
+        "export function UsersPage() {\n"
+        "  const { t } = useTranslation();\n"
+        "  return <h1>{t('admin.users.title')}</h1>;\n"
+        "}\n"
+    ),
+}
+
+proc = run_audit(DYNAMIC_LOCALE, DYNAMIC_SOURCE, "--json")
+report = json.loads(proc.stdout)
+
+check(
+    "no key under the dynamic prefix is reported unused",
+    [entry["key"] for entry in report["unused"]] == [],
+)
+
+check(
+    "those keys are reported as undeterminable instead",
+    [entry["key"] for entry in report["undeterminable"]]
+    == ["admin.users.roles.guest", "admin.users.roles.moderator", "admin.users.roles.owner"],
+)
+
+check(
+    "undeterminable keys do not count as issues",
+    report["summary"]["totalIssues"] == 0
+    and report["summary"]["unusedCount"] == 0
+    and report["summary"]["undeterminableCount"] == 3,
+)
+
+check(
+    "an unresolvable key does not fail the exit code",
+    proc.returncode == 0,
+)
+
+# A genuinely dead key must still be reported, or the fix has simply silenced
+# the whole check.
+proc = run_audit(
+    {**DYNAMIC_LOCALE, "checkout": {"abandonedBasketNotice": "Je mandje wacht"}},
+    DYNAMIC_SOURCE,
+    "--json",
+)
+report = json.loads(proc.stdout)
+
+check(
+    "a dead key outside the dynamic prefix is still reported unused",
+    [entry["key"] for entry in report["unused"]] == ["checkout.abandonedBasketNotice"]
+    and report["summary"]["totalIssues"] == 1
+    and proc.returncode == 1,
+)
+
+
+# --- text report: the reader must be told the unused list is not reliable ---
+
+proc = run_audit(DYNAMIC_LOCALE, DYNAMIC_SOURCE)
+text = proc.stdout
+
+check(
+    "unused block carries a warning while dynamic keys exist",
+    "WARNING: 1 dynamic key(s) detected" in text,
+)
+
+check(
+    "undeterminable keys get their own section with the covering prefix",
+    "── Undeterminable Keys (3)" in text and "admin.users.roles.*  (3 key(s))" in text,
+)
+
+check(
+    "summary reports the undeterminable count separately from unused",
+    "Unused: 0 | Undeterminable: 3" in text and "Result: CLEAN" in text,
+)
+
+# Without dynamic keys the warning must be absent, or it becomes noise that
+# readers learn to ignore.
+proc = run_audit(
+    {"checkout": {"abandonedBasketNotice": "Je mandje wacht"}},
+    {
+        "Cart.tsx": (
+            "import { useTranslation } from 'react-i18next';\n"
+            "export function Cart() {\n"
+            "  const { t } = useTranslation();\n"
+            "  return <p>{t('checkout.otherNotice')}</p>;\n"
+            "}\n"
+        )
+    },
+)
+
+check(
+    "no warning when the project has no dynamic keys",
+    "WARNING:" not in proc.stdout and "── Undeterminable Keys (0)" in proc.stdout,
+)
+
+
 # --- summary ---
 
 print()

--- a/bin/test-i18n-audit.py
+++ b/bin/test-i18n-audit.py
@@ -343,6 +343,47 @@ check(
 )
 
 
+# --- dynamic key listing: truncating hides what cannot be verified by hand ---
+
+MANY_DYNAMIC_SOURCE = {
+    f"Widget{n}.tsx": (
+        "import { useTranslation } from 'react-i18next';\n"
+        f"export function Widget{n}() {{\n"
+        "  const { t } = useTranslation();\n"
+        f"  return <span>{{t(`widget.section{n}.${{key}}`)}}</span>;\n"
+        "}\n"
+    )
+    for n in range(15)
+}
+MANY_DYNAMIC_LOCALE = {
+    "widget": {f"section{n}": {"label": f"Label {n}"} for n in range(15)}
+}
+
+proc = run_audit(MANY_DYNAMIC_LOCALE, MANY_DYNAMIC_SOURCE)
+
+check(
+    "every dynamic prefix is listed by default",
+    all(f"widget.section{n}." in proc.stdout for n in range(15))
+    and "more" not in proc.stdout,
+)
+
+proc = run_audit(MANY_DYNAMIC_LOCALE, MANY_DYNAMIC_SOURCE, "--dynamic-limit", "5")
+shown = sum(1 for n in range(15) if f"`widget.section{n}." in proc.stdout)
+
+check(
+    "--dynamic-limit caps the listing and says how many were hidden",
+    shown == 5 and "... and 10 more" in proc.stdout,
+)
+
+proc = run_audit(MANY_DYNAMIC_LOCALE, MANY_DYNAMIC_SOURCE, "--dynamic-limit", "5", "--json")
+report = json.loads(proc.stdout)
+
+check(
+    "--json ignores the limit and stays complete",
+    len(report["dynamicKeys"]) == 15,
+)
+
+
 # --- summary ---
 
 print()

--- a/bin/test-i18n-audit.py
+++ b/bin/test-i18n-audit.py
@@ -165,6 +165,47 @@ check(
 )
 
 
+# --- split_undeterminable: unused keys a dynamic call site could reach ---
+#
+# The audit already knows `admin.users.roles.${role}` exists. Every key under
+# that prefix is reachable at runtime, so listing it as unused hands the reader
+# a cleanup list that deletes working translations.
+
+unused, undeterminable = audit.split_undeterminable(
+    {
+        "admin.users.roles.moderator",
+        "admin.users.roles.owner",
+        "admin.users.deletedColumnHeader",
+        "profile.types.solo",
+    },
+    {"admin.users.roles.", "profile.types."},
+)
+
+check(
+    "keys under a detected prefix move to undeterminable",
+    undeterminable
+    == {"admin.users.roles.moderator", "admin.users.roles.owner", "profile.types.solo"},
+)
+
+check(
+    "a key outside every prefix stays unused",
+    unused == {"admin.users.deletedColumnHeader"},
+)
+
+check(
+    "no prefixes leaves the unused set untouched",
+    audit.split_undeterminable({"a.b", "c.d"}, set()) == ({"a.b", "c.d"}, set()),
+)
+
+# The prefix ends in a dot, so `admin.usersOverview` must not be swallowed by
+# the `admin.users.` prefix through a plain startswith on a dotless boundary.
+check(
+    "a sibling key sharing a text prefix is not swallowed",
+    audit.split_undeterminable({"admin.usersOverview"}, {"admin.users."})
+    == ({"admin.usersOverview"}, set()),
+)
+
+
 # --- summary ---
 
 print()

--- a/bin/test-i18n-audit.py
+++ b/bin/test-i18n-audit.py
@@ -106,6 +106,65 @@ check(
 )
 
 
+# --- extract_static_prefix: the part of a dynamic key that IS knowable ---
+#
+# `t(`admin.users.roles.${role}`)` cannot be resolved statically, but everything
+# before the first `${` is a literal namespace. That prefix is what tells us
+# which locale keys the call reaches.
+
+check(
+    "static prefix is everything before the first interpolation",
+    audit.extract_static_prefix("admin.users.roles.${role}")
+    == "admin.users.roles.",
+)
+
+check(
+    "trailing segment after the interpolation is ignored",
+    audit.extract_static_prefix("profile.types.${type}.label") == "profile.types.",
+)
+
+check(
+    "i18next namespace prefix is stripped like elsewhere",
+    audit.extract_static_prefix("common:admin.users.roles.${role}")
+    == "admin.users.roles.",
+)
+
+# A pattern that interpolates from the very start has no static part at all.
+# Returning "" would match every key in the locale and silently empty the
+# unused report, so it must yield nothing.
+check(
+    "leading interpolation yields no usable prefix",
+    audit.extract_static_prefix("${namespace}.roles.admin") is None,
+)
+
+check(
+    "prefix of a single segment is still usable",
+    audit.extract_static_prefix("roles.${role}") == "roles.",
+)
+
+# `t(`errors.${code}`)` names a real namespace; `t(`${a}${b}`)` does not.
+check(
+    "interpolation not preceded by a dot yields no prefix",
+    audit.extract_static_prefix("errorCode${code}") is None,
+)
+
+
+# --- dynamic_prefixes: the set over all detected dynamic call sites ---
+
+check(
+    "prefixes are collected across call sites and deduplicated",
+    audit.dynamic_prefixes(
+        [
+            ("admin.users.roles.${role}", "src/UserTable.tsx", 42),
+            ("admin.users.roles.${r}", "src/RoleBadge.tsx", 17),
+            ("profile.types.${profile.type}", "src/ProfileCard.tsx", 88),
+            ("${ns}.whatever", "src/Dynamic.tsx", 3),
+        ]
+    )
+    == {"admin.users.roles.", "profile.types."},
+)
+
+
 # --- summary ---
 
 print()

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -28,6 +28,11 @@ Run the requested audit(s). When `$ARGUMENTS` is empty or `all`, run all audits 
 ```
 Finds missing/unused/inconsistent i18n keys. Only applicable to frontend projects with locale files.
 
+Keys sitting under a detected dynamic prefix (`t(\`admin.roles.${role}\`)`) land in a separate
+**Undeterminable** bucket: they are reachable at runtime, so they are not counted as issues and
+never appear in the unused list. Use `--json` for the full undeterminable key list, and
+`--dynamic-limit N` to shorten the dynamic-key listing in the text report.
+
 **env** — Environment variable audit:
 ```bash
 ~/.claude/bin/env-audit.sh
@@ -50,7 +55,10 @@ Checks for unpinned images, missing health checks, root users, hardcoded secrets
 
 1. Present a combined summary of all audit results.
 2. For any issues found, offer concrete next steps:
-   - **i18n**: add missing keys, remove unused keys
+   - **i18n**: add missing keys, remove unused keys. Never propose deleting an
+     **undeterminable** key — the audit reports it precisely because it cannot tell
+     whether the key is live. When the report carries the dynamic-key warning, the
+     unused list still deserves a manual check before anything is deleted.
    - **env**: create missing variables, fill empty values
    - **deps**: suggest `npm audit fix` or package updates
    - **docker**: suggest specific fixes (pin versions, add HEALTHCHECK, add USER)


### PR DESCRIPTION
Closes #42

## Summary

`i18n-audit.py` already detected dynamic call sites like `` t(`admin.users.roles.${role}`) `` and listed them separately, but every key those calls reach stayed in the unused list. Anyone treating that list as a cleanup list deleted working translations.

Unused keys covered by a detected dynamic prefix now move into a separate **undeterminable** bucket. They are not dead keys; they are keys whose use cannot be determined statically, and the report no longer conflates the two.

## Changes

- `extract_static_prefix()` — everything before the first `${`, with the i18next namespace stripped. Returns `None` when the result would not name a namespace (leading interpolation, or interpolation inside a segment like `errorCode${code}`), because an over-broad prefix would silently empty the unused report.
- `split_undeterminable()` — partitions the unused set. Prefixes end in a dot, so matching is on the segment boundary: `admin.users.` covers `admin.users.roles.owner` but not the unrelated sibling `admin.usersOverview`.
- Undeterminable keys stay out of the unused count, out of `totalIssues`, and out of the exit code. An unresolvable key is not an actionable issue.
- Text report gains an `── Undeterminable Keys (N) ──` section listing the covering prefixes and their key counts, plus a `WARNING` above the unused block whenever dynamic keys were detected. The warning is absent when there are none, so it does not become noise.
- JSON output gains an `undeterminable` array (each entry carries the `prefix` that covers it, longest match) and `summary.undeterminableCount`.
- The dynamic-key listing no longer truncates at 10. New `--dynamic-limit N` restores a cap; `--json` is always complete regardless.
- `/audit` skill guidance updated: never propose deleting an undeterminable key.

Both new helpers are deliberately standalone so #3 can reuse the prefix extraction for the opposite question (a prefix matching *zero* locale keys).

## Tests

`python3 bin/test-i18n-audit.py` — **29/29 passing** (was 6).

- [x] Static prefix extraction, including the two cases that must yield no prefix
- [x] Prefixes collected and deduplicated across call sites
- [x] Keys under a prefix move to undeterminable; keys outside stay unused
- [x] A sibling key sharing a text prefix is not swallowed
- [x] End-to-end: unused list empty, exit code 0, counts correct
- [x] End-to-end negative: a genuinely dead key is still reported and still exits 1
- [x] Warning present with dynamic keys, absent without
- [x] All 15 prefixes listed by default; `--dynamic-limit 5` truncates; `--json` stays complete

Mutation-checked: stubbing out the split makes 7 of these tests fail, so they test the behaviour rather than that the code runs.

Verified separately across 16 combinations (2 fixture projects × 4 `--check` values × text/`--json`) with no tracebacks. In particular `--check missing --json` emits no `undeterminable` array and reports `undeterminableCount: null` rather than a misleading zero.

On a fixture using both patterns the unused total dropped from 8 to 2, with the 6 filtered keys accounted for in the undeterminable bucket.

## Known trade-off

A key nested deeper than the interpolation can reach (`admin.users.roles.deep.nested.dead` under `` t(`admin.users.roles.${role}`) ``) is still classified undeterminable, so the bucket can hide a genuinely dead key. This is the conservative direction on purpose: the bucket exists to stop unsafe deletions, and the per-key `prefix` field in `--json` gives the reader what they need to audit it by hand.
