### PR TITLE
fix(bin): diagnose "not fully merged" instead of blindly advising -D

### DIFF
--- a/bin/git-cleanup-merged-branch.sh
+++ b/bin/git-cleanup-merged-branch.sh
@@ -114,9 +114,74 @@ if git branch --merged "$BASE_BRANCH" | grep -q "^[* ]*$FEATURE_BRANCH$"; then
         fi
     fi
 else
-    echo -e "${RED}Error: Branch '$FEATURE_BRANCH' is not fully merged into '$BASE_BRANCH'${NC}"
-    echo "Use 'git branch -D $FEATURE_BRANCH' to force delete (will lose unmerged changes!)"
-    exit 1
+    # "Not fully merged" means the branch tip is not an ancestor of the base --
+    # a reachability fact, not a content fact. The two diverge whenever history
+    # was rewritten (cherry-pick, rebase, squash-merge), so the raw warning
+    # cannot tell "work would be lost" apart from "already applied under a new
+    # commit". Diagnose both before suggesting anything destructive.
+    echo -e "${YELLOW}Branch '$FEATURE_BRANCH' is not fully merged into '$BASE_BRANCH'${NC}"
+    echo "Diagnosing whether that means unmerged work or rewritten history..."
+
+    UNIQUE_COMMITS=$(git log --oneline "$BASE_BRANCH".."$FEATURE_BRANCH")
+
+    if [ -z "$UNIQUE_COMMITS" ]; then
+        # No unique commits: only a local merge-commit is unreachable.
+        echo -e "\n${GREEN}✓ No unique commits. Nothing would be lost.${NC}"
+        echo "  (Typically a local '$BASE_BRANCH'-into-feature merge that GitHub"
+        echo "   superseded with its own merge commit.)"
+        SAFE_TO_FORCE=1
+    else
+        echo -e "\n${YELLOW}Commits not reachable from '$BASE_BRANCH':${NC}"
+        echo "$UNIQUE_COMMITS" | sed 's/^/  /'
+
+        # Content check. Two dots is deliberate: it compares the two tips, so an
+        # empty result proves the branch adds nothing the base lacks. (Three dots
+        # would diff from the merge-base and hide base-side changes -- the wrong
+        # question here.)
+        if [ -z "$(git diff "$BASE_BRANCH" "$FEATURE_BRANCH")" ]; then
+            echo -e "\n${GREEN}✓ ...but the trees are identical.${NC}"
+            echo "  The content already landed under different commit hashes"
+            echo "  (cherry-pick, rebase, or squash-merge). Nothing would be lost."
+            SAFE_TO_FORCE=1
+        else
+            echo -e "\n${RED}✗ These commits contain content missing from '$BASE_BRANCH'.${NC}"
+            echo "  Files that differ:"
+            git diff --stat "$BASE_BRANCH" "$FEATURE_BRANCH" | sed 's/^/    /'
+            SAFE_TO_FORCE=0
+        fi
+    fi
+
+    if [ "$SAFE_TO_FORCE" = "1" ]; then
+        echo
+        read -p "Force-delete '$FEATURE_BRANCH'? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            git branch -D "$FEATURE_BRANCH"
+            echo -e "${GREEN}✓ Deleted local branch '$FEATURE_BRANCH'${NC}"
+
+            if git ls-remote --exit-code --heads origin "$FEATURE_BRANCH" &>/dev/null; then
+                echo -e "\n${YELLOW}Remote branch 'origin/$FEATURE_BRANCH' still exists${NC}"
+                read -p "Delete remote branch? (y/N) " -n 1 -r
+                echo
+                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                    git push origin --delete "$FEATURE_BRANCH"
+                    echo -e "${GREEN}✓ Deleted remote branch 'origin/$FEATURE_BRANCH'${NC}"
+                fi
+            fi
+        else
+            echo "Left '$FEATURE_BRANCH' in place."
+            exit 1
+        fi
+    else
+        echo
+        echo -e "${RED}Refusing to delete: this branch holds work that exists nowhere else.${NC}"
+        echo "Rescue it first, for example:"
+        echo "  git cherry-pick <commit>   # replay onto $BASE_BRANCH, then re-run cleanup"
+        echo "  gh pr create --base $BASE_BRANCH --head $FEATURE_BRANCH"
+        echo
+        echo "If you are certain it is disposable: git branch -D $FEATURE_BRANCH"
+        exit 1
+    fi
 fi
 
 echo -e "\n${GREEN}=== Cleanup Complete ===${NC}"


### PR DESCRIPTION
Vervangt het blinde `-D`-advies in stap 4 door een echte diagnose.

`git branch -d` toetst bereikbaarheid, niet inhoud. Die twee lopen uiteen zodra
history herschreven is (cherry-pick, rebase, squash-merge), dus de oude
foutmelding gaf hetzelfde advies in twee tegengestelde situaties: één waarin
niets verloren gaat, en één waarin `-D` de enige kopie van werk vernietigt.

## Gedrag na deze wijziging

| Situatie | Uitkomst |
|---|---|
| Lege `git log base..branch` | "niets zou verloren gaan", vraagt bevestiging |
| Niet-leeg + lege `git diff base branch` | "inhoud al geland onder andere hash", vraagt bevestiging |
| Niet-leeg + niet-lege diff | **weigert**, toont verschillende files, stelt cherry-pick/PR voor |

Tweepunts-diff is bewust: die vergelijkt de twee tips, dus leeg bewijst dat de
branch niets toevoegt. Driepunts zou vanaf de merge-base kijken en base-side
wijzigingen verbergen.

## Verificatie

Beide paden gedraaid tegen de echte repo-state die dit opleverde:

- Cherry-picked branch → "✓ ...but the trees are identical", branch blijft staan bij `n`
- Branch met unieke inhoud → "✗ Refusing to delete", branch bestaat daarna nog steeds

`bash -n` schoon; pre-commit secret scan groen.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
