### PR TITLE
docs(skills): tell retro and promote to strip project context

### DIFF
--- a/skills/promote/SKILL.md
+++ b/skills/promote/SKILL.md
@@ -42,6 +42,25 @@ Create a parameterised version that:
 - Includes a usage comment explaining all parameters
 - Works as a standalone script or can be sourced
 
+**The toolkit repo is PUBLIC — generalise the prose too, not just the code.**
+
+The same strip applies to comments, docs, and to the **GitHub issue bodies, PR bodies
+and commit messages** you write against the toolkit repo. Remove project names,
+client/person names, product URLs and hostnames, and internal issue/PR numbers from
+other repos. Keep the lesson, the reasoning, and load-bearing numbers — without the
+attribution. The project-local version keeps the full story.
+
+Note that an issue number from another project renders as a link to *this* repo's issue
+with that number, so it leaks and misleads at once. And `gh issue edit` does not undo a
+published leak — GitHub keeps the old body in the "edited" menu, so cleaning up means
+delete + recreate.
+
+Scan before publishing:
+
+```bash
+grep -oiE "<project>|<client>|<product-domain>|#[0-9]{3}" <body-file>
+```
+
 ## Phase 3: Determine Toolkit Location
 
 Check the toolkit repo for existing similar scripts/skills before creating duplicates.
@@ -129,3 +148,4 @@ Wait for confirmation before making any changes.
 - Check the toolkit for existing similar scripts/skills before creating duplicates.
 - If a toolkit proposal file exists for this pattern, use it as input but verify it is still accurate.
 - Clean up the toolkit proposal file after successful promotion.
+- The toolkit repo is public: never put project names, client names, product URLs or other repos' issue/PR numbers in toolkit files, issues, PRs or commit messages. Generalise the lesson, drop the attribution.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -181,7 +181,37 @@ Steps:
 
 ### For toolkit candidates
 
-Do everything above for the project-local version, then ALSO create a proposal file at `~/.claude/toolkit-proposals/<name>.md` containing:
+**The toolkit repo is PUBLIC. Strip project-identifying context before anything goes there.**
+
+This applies to every artefact that lands in the toolkit — proposal files, `rules/`,
+`skills/`, `claude-md/`, and just as much to the **GitHub issue bodies, PR bodies and
+commit messages** you write against that repo. The project-local version keeps the full
+story; the toolkit version gets the generalised lesson.
+
+Remove: project names, client/person names, product URLs and hostnames, and internal
+issue/PR numbers from other repos. Keep: the lesson, the reasoning, and any number that
+is load-bearing for the lesson (pool sizes, timeouts) — without the attribution.
+
+Write "a FastAPI project shipped dozens of async-def routes holding a sync Session",
+not the named-project version. Say "measured in a project repo (2026-05-12)", not
+"measured in <Project> #<nr>".
+
+Two traps worth knowing:
+
+- An issue number from another project renders as a link to *this* repo's issue with
+  that number — a leak and a wrong reference at once.
+- `gh issue edit` does NOT clean up a body that was already published: GitHub keeps the
+  previous version in the "edited" menu. Fixing a leak means `gh issue delete` +
+  recreate, `gh pr close --delete-branch`, and rewriting the commit message if it
+  carried the context too.
+
+Scan the body before publishing, not after:
+
+```bash
+grep -oiE "<project>|<client>|<product-domain>|#[0-9]{3}" <body-file>
+```
+
+Then do everything above for the project-local version, and ALSO create a proposal file at `~/.claude/toolkit-proposals/<name>.md` containing:
 - Name and one-line description
 - The problem pattern it solves (generic, not project-specific)
 - Which projects would benefit
@@ -227,3 +257,4 @@ Artefacts:
 - For design decisions, capture the reasoning and the alternatives considered — not just the final choice.
 - When in doubt about toolkit candidacy, keep it project-local. Promote later via `/promote`.
 - Claude Code tool behaviour (permissions, Bash patterns, sandbox workarounds) ALWAYS goes to memory, never to `docs/development/`.
+- The toolkit repo is public: never put project names, client names, product URLs or other repos' issue/PR numbers in toolkit files, issues, PRs or commit messages. Generalise the lesson, drop the attribution.


### PR DESCRIPTION
Deze repo is publiek, maar de skills die eráán schrijven zeiden dat nergens.
`/retro` en `/promote` sluizen allebei projectlokale lessen hierheen, en geen van
beide waarschuwde specifiek voor de GitHub-artefacten — dus issue-bodies,
PR-bodies en commit messages bleven projectnamen en issue-nummers uit andere
repo's meenemen.

## Wijziging

- `/retro`: strip-instructie in de toolkit-candidates-sectie
- `/promote`: idem in Phase 2 (Generalise), die tot nu toe alleen over code ging
- Beide: één regel in de Rules-sectie, zodat het ook zichtbaar is zonder de
  hele sectie te lezen

Benoemt wat weg moet (project-/klantnamen, product-URLs, issue-nummers uit andere
repo's) en wat blijft (de les, de redenering, dragende getallen zonder attributie).

## Twee valkuilen die dit duur maakten om te repareren

- Een issue-nummer uit een ander project rendert hier als link naar *dit* repo's
  issue met dat nummer: een lek en een verkeerde verwijzing tegelijk.
- `gh issue edit` maakt een gepubliceerd lek niet ongedaan — GitHub bewaart de
  oude body in het "edited"-menu. Opschonen betekent verwijderen + opnieuw
  aanmaken, en de commit message herschrijven als die de context ook droeg.

## Scope

Dekt het derde acceptatiecriterium van #16. De sweep van bestaande `rules/`,
`skills/` en `claude-md/` op al aanwezige projectverwijzingen (criteria 1, 2 en 4)
staat hier bewust niet in — daarom `Addresses` en geen `Closes`, zodat #16
open blijft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
