### PR TITLE
feat(hook): enforce Co-Authored-By trailer on agent commits

### DIFF
--- a/bin/hook-post-commit-trailer.sh
+++ b/bin/hook-post-commit-trailer.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# PostToolUse hook that ensures agent-authored commits carry the
+# Co-Authored-By trailer.
+#
+# Why this exists as a hook and not in git-commit.sh: that script is also used
+# by the human maintainer from a normal terminal. Hardcoding the trailer there
+# would label human commits as agent-authored, which destroys the distinction
+# the `agent-authored` label (and the heightened-review gate behind it) depends
+# on. A PostToolUse hook only fires when the agent commits through the Bash
+# tool, so human commits stay untouched.
+#
+# Without the trailer, repositories that auto-apply an `agent-authored` label
+# never apply it, and any required checklist gate keyed to that label never
+# runs — a review gate that is green because it never executed.
+#
+# Advisory-but-corrective: amends the trailer in and reports on stderr so the
+# agent sees what happened. Always exits 0; a failure to amend must never break
+# the session.
+#
+# Installation: register in settings.json (project or global):
+#   {
+#     "hooks": {
+#       "PostToolUse": [{
+#         "matcher": "Bash",
+#         "hooks": [{ "type": "command", "command": "~/.claude/bin/hook-post-commit-trailer.sh" }]
+#       }]
+#     }
+#   }
+#
+# Skips:
+#   - Bash calls that did not commit
+#   - Commits that already carry the trailer
+#   - Repos with no commit yet, or a detached/unborn HEAD
+#   - Merge commits (the trailer belongs on the authored commit)
+
+set -uo pipefail
+
+TRAILER="Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Only act on commands that actually create a commit. git-commit.sh is the
+# sanctioned path; raw `git commit` is matched too so the trailer does not
+# depend on which one was used.
+if ! echo "$COMMAND" | grep -qE '(git-commit\.sh|git +(-C +[^ ]+ +)?commit)'; then
+    exit 0
+fi
+
+# --amend --no-edit reuses an existing message; re-amending it here would loop
+# on a message this hook itself just wrote.
+if echo "$COMMAND" | grep -q -- '--no-edit'; then
+    exit 0
+fi
+
+# Resolve the repo the command operated on: an explicit `git -C <dir>` wins,
+# otherwise the working directory of the session.
+REPO_DIR=$(echo "$COMMAND" | grep -oE 'git +-C +[^ ]+' | head -1 | awk '{print $3}')
+if [[ -z "$REPO_DIR" ]]; then
+    REPO_DIR=$(echo "$INPUT" | jq -r '.cwd // empty')
+fi
+[[ -z "$REPO_DIR" || ! -d "$REPO_DIR" ]] && exit 0
+
+git -C "$REPO_DIR" rev-parse --verify HEAD &>/dev/null || exit 0
+
+# A hook that rewrites a commit already pushed would desync the remote.
+if git -C "$REPO_DIR" branch -r --contains HEAD 2>/dev/null | grep -q .; then
+    exit 0
+fi
+
+# Merge commits are not authored content.
+if [[ $(git -C "$REPO_DIR" rev-list --no-walk --count --merges HEAD 2>/dev/null) == "1" ]]; then
+    exit 0
+fi
+
+MESSAGE=$(git -C "$REPO_DIR" log -1 --format='%B' 2>/dev/null)
+if echo "$MESSAGE" | grep -qi "^Co-Authored-By:"; then
+    exit 0
+fi
+
+# Verify the commit is recent: a Bash call that merely *mentioned* commit
+# (a grep over history, a --dry-run) must not rewrite an older commit.
+COMMIT_AGE=$(( $(date +%s) - $(git -C "$REPO_DIR" log -1 --format='%ct' 2>/dev/null || echo 0) ))
+if (( COMMIT_AGE > 120 )); then
+    exit 0
+fi
+
+if git -C "$REPO_DIR" commit --amend --no-edit --no-verify \
+        --trailer "$TRAILER" &>/dev/null; then
+    echo "hook: added missing '$TRAILER' to HEAD (agent-authored label depends on it)" >&2
+else
+    echo "hook: could not add Co-Authored-By trailer to HEAD; add it manually so the agent-authored label applies" >&2
+fi
+
+exit 0

--- a/bin/tests/test-hook-post-commit-trailer.sh
+++ b/bin/tests/test-hook-post-commit-trailer.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Tests for hook-post-commit-trailer.sh.
+#
+# Usage:
+#   bin/tests/test-hook-post-commit-trailer.sh
+#
+# Exercises the hook against throwaway git repos in a temp dir. Nothing outside
+# that temp dir is touched. Exits non-zero on the first failing expectation.
+#
+# The hook rewrites commits (git commit --amend), so the guards that stop it
+# from rewriting the WRONG commit are the load-bearing part. Cases 3-6 and 9
+# exist for those guards specifically: case 9 (already pushed) is what keeps the
+# hook from rewriting published history, and it was added after a mutation run
+# showed the suite stayed green with that guard deleted.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="${HOOK_UNDER_TEST:-$SCRIPT_DIR/../hook-post-commit-trailer.sh}"
+
+if [[ ! -f "$HOOK" ]]; then
+    echo "hook not found: $HOOK" >&2
+    exit 1
+fi
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+PASS=0; FAIL=0
+
+check() { # name expected actual
+    if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1))
+    else echo "  FAIL: $1 (expected $2, got $3)"; FAIL=$((FAIL+1)); fi
+}
+
+has_trailer() {
+    git -C "$1" log -1 --format='%B' | grep -qi "^Co-Authored-By:" && echo yes || echo no
+}
+
+fire() { # repodir command  — feed the hook a PostToolUse payload
+    printf '{"tool_input":{"command":%s},"cwd":%s}' \
+        "$(jq -Rn --arg c "$2" '$c')" "$(jq -Rn --arg d "$1" '$d')" | bash "$HOOK" 2>/dev/null
+}
+
+newrepo() {
+    local d="$T/$1"; mkdir -p "$d"; git -C "$d" init -q
+    git -C "$d" config user.email t@t; git -C "$d" config user.name T
+    echo x > "$d/f"; git -C "$d" add f
+    echo "$d"
+}
+
+echo "== 1. plain commit without trailer -> added =="
+R=$(newrepo r1); git -C "$R" commit -qm "feat: thing"
+fire "$R" "git -C $R commit -m 'feat: thing'"
+check "trailer added" yes "$(has_trailer "$R")"
+
+echo "== 2. commit that already has a trailer -> untouched =="
+R=$(newrepo r2)
+git -C "$R" commit -qm "feat: thing
+
+Co-Authored-By: Someone <s@example.com>"
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R commit -m x"
+check "sha unchanged" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+
+echo "== 3. non-commit bash call -> untouched =="
+R=$(newrepo r3); git -C "$R" commit -qm "feat: thing"
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R log --oneline -5"
+check "sha unchanged" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+check "no trailer added" no "$(has_trailer "$R")"
+
+echo "== 4. old commit (>120s) -> untouched =="
+R=$(newrepo r4)
+GIT_COMMITTER_DATE="2020-01-01T00:00:00" git -C "$R" commit -qm "feat: old" --date "2020-01-01T00:00:00"
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R commit -m x"
+check "sha unchanged" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+
+echo "== 5. merge commit -> untouched =="
+R=$(newrepo r5); git -C "$R" commit -qm base
+git -C "$R" checkout -qb side; echo y > "$R/g"; git -C "$R" add g; git -C "$R" commit -qm side
+git -C "$R" checkout -q master 2>/dev/null || git -C "$R" checkout -q main
+echo z > "$R/h"; git -C "$R" add h; git -C "$R" commit -qm mainline
+git -C "$R" merge --no-ff -q side -m "Merge branch 'side'" 2>/dev/null
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R commit -m x"
+check "merge untouched" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+
+echo "== 6. --no-edit amend -> untouched (no loop) =="
+R=$(newrepo r6); git -C "$R" commit -qm "feat: thing"
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R commit --amend --no-edit"
+check "sha unchanged" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+
+echo "== 7. wrapper-script form -> added =="
+R=$(newrepo r7); git -C "$R" commit -qm "feat: thing"
+fire "$R" "cd $R; ~/.claude/bin/git-commit.sh 'feat: thing'"
+check "trailer added" yes "$(has_trailer "$R")"
+
+echo "== 8. cwd fallback (no -C in command) -> added =="
+R=$(newrepo r8); git -C "$R" commit -qm "feat: thing"
+fire "$R" "git commit -m 'feat: thing'"
+check "trailer added via cwd" yes "$(has_trailer "$R")"
+
+echo "== 9. already pushed to a remote -> untouched (no history rewrite) =="
+R=$(newrepo r9); git -C "$R" commit -qm "feat: thing"
+BARE="$T/r9-remote.git"; git init -q --bare "$BARE"
+git -C "$R" remote add origin "$BARE"
+git -C "$R" push -q origin HEAD 2>/dev/null
+BEFORE=$(git -C "$R" rev-parse HEAD)
+fire "$R" "git -C $R commit -m 'feat: thing'"
+check "pushed commit untouched" "$BEFORE" "$(git -C "$R" rev-parse HEAD)"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -61,6 +61,8 @@ ALTIJD `~/.claude/bin/git-commit.sh` — NOOIT raw `git commit`.
 
 NOOIT: `git commit -m`, `git commit -F`, heredocs, multi-arg met veel regels, of Bash voor file-aanmaak.
 
+**Co-Authored-By-trailer.** Elke agent-commit eindigt met de `Co-Authored-By`-trailer. Repo's die zwaardere review ophangen aan een `agent-authored`-label passen dat label zonder trailer nooit toe, waardoor de bijbehorende verplichte checklist stil niet draait — een groene gate die nooit gedraaid heeft. **Enforced, not advisory:** `hook-post-commit-trailer.sh` (PostToolUse op Bash) voegt de trailer alsnog toe aan een verse, ongepushte, niet-merge commit en meldt dat op stderr. Bewust NIET in `git-commit.sh`: dat script gebruik je ook zelf, en een trailer daar zou je eigen commits als agent-authored bestempelen.
+
 ### Git branches
 
 Werk aan een issue → branchnaam VERPLICHT `issue-<nummer>-<slug>`, waar `<slug>` een korte kebab-case samenvatting van de issue-titel is. Bijv. issue #3 "Per-feature code discipline" → `issue-3-code-discipline`. Zo is elke branch traceerbaar naar zijn issue. Branches zonder issue (los experiment) mogen afwijken.

--- a/claude-md/settings-global.jsonc
+++ b/claude-md/settings-global.jsonc
@@ -133,6 +133,21 @@
             "command": "~/.claude/bin/hook-post-edit-lint.sh"
           }
         ]
+      },
+      {
+        // Adds the Co-Authored-By trailer to agent-authored commits when it is
+        // missing. Repos that gate heightened review on an `agent-authored`
+        // label never apply that label without the trailer, so the required
+        // checklist silently never runs. Deliberately NOT in git-commit.sh:
+        // that wrapper is also used by the human maintainer, and a trailer
+        // there would label human commits as agent-authored.
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/bin/hook-post-commit-trailer.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Wat

Een PostToolUse-hook die de `Co-Authored-By`-trailer alsnog in een agent-commit zet als die ontbreekt, plus de bijbehorende testsuite en de documentatie/registratie ervan.

## Waarom

Repo's die zwaardere review ophangen aan een `agent-authored`-label passen dat label nooit toe zonder de trailer. De verplichte checklist die aan dat label hangt draait dan stil niet: een review-gate die groen is omdat hij nooit gedraaid heeft.

Bewust **niet** in `git-commit.sh`. Dat script gebruikt de maintainer ook zelf vanaf een gewone terminal; een trailer daar zou menselijke commits als agent-authored bestempelen en precies het onderscheid slopen waar het label op leunt. Een PostToolUse-hook vuurt alleen als de agent via de Bash-tool commit.

## Guards

De hook herschrijft commits (`git commit --amend`), dus het load-bearing deel is wat hem tegenhoudt bij de *verkeerde* commit:

- al gepusht naar een remote (zou gepubliceerde history desyncen)
- merge-commits (geen authored content)
- commit ouder dan 120s (een Bash-call die commit alleen *noemt*, zoals een grep over history of een `--dry-run`)
- `--amend --no-edit` (zou loopen op het bericht dat de hook zelf schreef)
- Bash-calls die niets committen
- trailer al aanwezig

## Tests

`bin/tests/test-hook-post-commit-trailer.sh` draait de hook tegen wegwerp-git-repo's in een tempdir; buiten die tempdir wordt niets aangeraakt. Negen cases, 10 assertions, allemaal groen:

```
PASS=10 FAIL=0
```

De pushed-commit-guard (case 9) is toegevoegd nadat een mutatierun liet zien dat de suite groen bleef met die guard verwijderd.

## Overig

- `claude-md/global.md`: paragraaf onder "Git commits" die de regel en de handhaving beschrijft
- `claude-md/settings-global.jsonc`: hook geregistreerd als PostToolUse op Bash
- Beide nieuwe scripts staan op mode `100755`, in lijn met de rest van `bin/`
