### PR TITLE
Make the checklist command matcher configurable

### DIFF
--- a/bin/hook-check-agent-review.sh
+++ b/bin/hook-check-agent-review.sh
@@ -24,6 +24,12 @@
 #                          `--repo owner/name` argument. Required.
 #   CHECKLIST_PATH_MATCH   Glob matched against $PWD, used when the command has
 #                          no --repo. Optional; no PWD fallback if unset.
+#   CHECKLIST_CMD_MATCH    Extended regex selecting the commands to inspect.
+#                          Default: bare `gh pr create|edit`. Override when the
+#                          project opens PRs through a wrapper script: the
+#                          wrapper's own name never contains `gh pr create`, so
+#                          the default silently skips the very call that needs
+#                          checking.
 #   CHECKLIST_START        Opening marker. Default: <!-- AGENT-REVIEW:START -->
 #   CHECKLIST_END          Closing marker. Default: <!-- AGENT-REVIEW:END -->
 #   CHECKLIST_TEMPLATE     Template path quoted in error messages.
@@ -50,6 +56,7 @@ set -euo pipefail
 
 REPO_MATCH="${CHECKLIST_REPO_MATCH:-}"
 PATH_MATCH="${CHECKLIST_PATH_MATCH:-}"
+CMD_MATCH="${CHECKLIST_CMD_MATCH:-(^|[;&|]|\s)gh\s+pr\s+(create|edit)\b}"
 START="${CHECKLIST_START:-<!-- AGENT-REVIEW:START -->}"
 END="${CHECKLIST_END:-<!-- AGENT-REVIEW:END -->}"
 TEMPLATE="${CHECKLIST_TEMPLATE:-.github/PULL_REQUEST_TEMPLATE.md}"
@@ -64,8 +71,8 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 [ -z "$COMMAND" ] && exit 0
 
-# Only gh pr create / gh pr edit.
-echo "$COMMAND" | grep -qE '(^|[;&|]|\s)gh\s+pr\s+(create|edit)\b' || exit 0
+# Only the PR-opening commands this project uses (see CHECKLIST_CMD_MATCH).
+echo "$COMMAND" | grep -qE "$CMD_MATCH" || exit 0
 
 # --repo wins when present, otherwise fall back to the working directory.
 if echo "$COMMAND" | grep -qE -- '--repo[= ]'; then


### PR DESCRIPTION
## Probleem

`hook-check-agent-review.sh` inspecteerde alleen commando's met een letterlijke `gh pr create` of `gh pr edit`:

```bash
echo "$COMMAND" | grep -qE '(^|[;&|]|\s)gh\s+pr\s+(create|edit)\b' || exit 0
```

Een project dat PR's opent via een wrapper-script roept `gh` **binnenin** dat script aan. De commandoregel die de hook te zien krijgt bevat die woorden dan nooit, dus de hook exit 0't zonder iets te controleren.

Het gevolg is precies wat deze hook hoort te voorkomen: de CI-gate die de checklist afdwingt gaat alsnog rood, minuten nadat de push al geland is. De guard ziet er van buiten gezond uit en meet niets.

## Wijziging

Het commandopatroon komt nu uit `CHECKLIST_CMD_MATCH`, met het bestaande patroon als default. Bestaande wrappers merken er niets van; een project met een eigen PR-vorm zet die erbij.

## Verificatie

Gemeten door de hook synthetische PreToolUse-payloads te voeren vanuit een bestand, met een body zonder checklist. Exit 2 = geblokkeerd, exit 0 = doorgelaten.

| geval | voor | na |
|---|---|---|
| `gh pr create`, checklist ontbreekt | 2 | 2 |
| wrapper-vorm, checklist ontbreekt | **0** | **2** |

Tegenprobe, want een guard die alles blokkeert is even nutteloos als een die niets blokkeert:

| geval | exit |
|---|---|
| wrapper + volledig afgevinkte checklist | 0 (doorgelaten) |
| niet-gerelateerd commando (`git status`) | 0 (vuurt niet) |
| ander repo via `--repo` | 0 (vuurt niet) |

`shellcheck` schoon.

## Voor wrapper-auteurs

Houd de `gh`-vormen in een override staan. Het aanmaken van een PR kan via de wrapper lopen terwijl een latere body-correctie een kale `gh pr edit` is; laat je die weg, dan staat hetzelfde gat weer open op het edit-pad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
