### PR TITLE
feat: pin the Playwright MCP output directory outside any checkout

### DIFF
--- a/claude-md/settings-global.jsonc
+++ b/claude-md/settings-global.jsonc
@@ -93,6 +93,33 @@
   },
   "alwaysThinkingEnabled": true,
 
+  // ── Environment ─────────────────────────────────────────────────
+  // PLAYWRIGHT_MCP_OUTPUT_DIR: where the Playwright MCP server writes
+  //   screenshots, traces and console logs.
+  //
+  //   Without it, the server's output directory defaults to its working
+  //   directory — which is the repository you are working in. A screenshot
+  //   taken WITHOUT a filename still lands in a `.playwright-mcp/` subdir
+  //   (commonly gitignored), but passing a `filename` writes a relative path
+  //   straight into the repo root, where nothing ignores it. That leaves an
+  //   untracked image one `git add .` away from being committed, in every
+  //   repo, forever.
+  //
+  //   Pointing it at a fixed directory outside any checkout fixes it once for
+  //   all projects instead of asking each repo for its own gitignore rule.
+  //   Verified against @playwright/mcp 0.0.79, which documents the variable
+  //   and its `--output-dir` equivalent.
+  //
+  //   __HOME__ is replaced with the real home directory by install.sh. It is
+  //   NOT a syntax Claude Code understands: an `env` value is passed to the
+  //   subprocess as a literal string, so neither `~` nor `${HOME}` is expanded
+  //   here — Playwright would resolve `~` into a directory actually named `~`.
+  //   (The `~/.claude/bin/...` hook commands lower down do work, because those
+  //   are run through a shell, which expands the tilde itself.)
+  "env": {
+    "PLAYWRIGHT_MCP_OUTPUT_DIR": "__HOME__/.claude/playwright-output"
+  },
+
   // ── Hooks ───────────────────────────────────────────────────────
   // Pre-tool hooks run BEFORE a tool executes. They work in ALL
   // permission modes, including bypass-permissions.

--- a/install.sh
+++ b/install.sh
@@ -48,10 +48,24 @@ fi
 if [ -e ~/.claude/settings.json ]; then
     echo "~/.claude/settings.json already exists. Remove it first if you want to reinstall."
 else
-    # Strip JSONC comments to produce valid JSON
+    # Strip JSONC comments to produce valid JSON, and expand __HOME__ into the
+    # real home directory. Values under "env" reach their subprocess as literal
+    # strings — nothing expands `~` or `${HOME}` for them — so the placeholder
+    # has to be resolved here, at install time, on the machine that has a $HOME.
     sed 's|//.*||' "$REPO_DIR/claude-md/settings-global.jsonc" | python3 -c "
-import sys, json
-json.dump(json.load(sys.stdin), sys.stdout, indent=2)
+import sys, json, os
+config = json.load(sys.stdin)
+
+def expand(value):
+    if isinstance(value, str):
+        return value.replace('__HOME__', os.path.expanduser('~'))
+    if isinstance(value, list):
+        return [expand(item) for item in value]
+    if isinstance(value, dict):
+        return {key: expand(item) for key, item in value.items()}
+    return value
+
+json.dump(expand(config), sys.stdout, indent=2)
 print()
 " > ~/.claude/settings.json
     echo "Installed: ~/.claude/settings.json (copied from settings-global.jsonc)"


### PR DESCRIPTION
## Wat

Zet `PLAYWRIGHT_MCP_OUTPUT_DIR` in de globale settings, zodat de Playwright MCP-server zijn screenshots, traces en console logs buiten elke checkout wegschrijft. `install.sh` vult daarbij het echte home-pad in.

## Waarom

Zonder die variabele schrijft de server relatief aan zijn working directory, en dat is de repo waar je op dat moment in werkt. Een screenshot *zonder* filename belandt nog in een `.playwright-mcp/`-submap die de meeste repo's al negeren, maar geef je wél een `filename` mee, dan gaat het bestand rechtstreeks naar de repo-root, waar niets het negeert. Dat is een untracked afbeelding op één `git add .` afstand van een commit — in elk project, telkens opnieuw.

Eén keer instellen lost dat overal op, in plaats van elke repo om een eigen gitignore-regel te vragen.

## De `__HOME__`-placeholder

De waarde bevat `__HOME__`, dat `install.sh` bij installatie vervangt. Dit is geen syntax die Claude Code zelf kent: een `env`-waarde gaat als letterlijke string naar het subprocess, dus niets expandeert daar `~` of `${HOME}` — Playwright zou `~` oplossen naar een map die daadwerkelijk `~` heet.

De `~/.claude/bin/...`-hookcommando's verderop in hetzelfde bestand zijn geen tegenvoorbeeld: die lopen via een shell, en die expandeert de tilde zelf.

De expansie in `install.sh` loopt de hele structuur af in plaats van deze ene key apart te behandelen, zodat een latere placeholder waar dan ook in de settings vanzelf meegaat.

## Verificatie

- Getest tegen `@playwright/mcp` 0.0.79, dat de variabele en zijn `--output-dir`-equivalent documenteert
- De install-pipeline (JSONC-comments strippen → expanderen → JSON) gedraaid op de gewijzigde settings: parset zonder fouten, levert `{"PLAYWRIGHT_MCP_OUTPUT_DIR": "/home/<user>/.claude/playwright-output"}` op, en er blijft geen `__HOME__` achter in de output

## Let op bij het uitrollen

`install.sh` schrijft `~/.claude/settings.json` alleen als dat bestand nog niet bestaat. Wie de toolkit al geïnstalleerd heeft, krijgt dit dus niet automatisch: daar moet het `env`-blok handmatig bij, of `settings.json` opnieuw gegenereerd worden.
