### PR TITLE
docs(skills): scope verification to the diff, keep formatters out of it

### DIFF
--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -631,6 +631,27 @@ npm run validate:all
 
 If validation fails, fix issues and commit directly to the feature branch.
 
+**Before committing anything here, check WHAT the validation changed.** Chains
+like `validate:all` typically end in a formatter and a code generator, and both
+WRITE to the tree. That churn is unrelated to the epic (regenerated API specs
+often differ only in unicode escaping), and this step is the one place the
+instruction above says to commit directly to a shared branch — so it is exactly
+where churn gets committed under a plausible-looking message.
+
+```bash
+git status --short          # anything you did not touch on purpose?
+git diff --stat             # churn is usually a large diff in a generated file
+```
+
+Revert generated-file churn (`git checkout -- <file>`) and commit only real
+fixes. If the diff is genuine (you changed a backend schema), regenerate
+deliberately and say so in the commit message.
+
+Scope the effort to what the epic actually touched: a check that cannot fail
+because of this epic's diff is wall-clock, not evidence. If the whole epic was
+frontend-only, the backend validators and the throwaway backend venv rebuild
+prove nothing — prefer the project's scoped variant where one exists.
+
 ### Step 2: Scoped regression tests
 
 Do NOT run the full test suite — sub-agents already ran their relevant tests.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -109,6 +109,39 @@ The orchestrator (main session) only:
 - Receives a structured summary
 - Decides whether to proceed to Phase 4 or fix issues
 
+### Step 0: Scope the verification to the diff's blast radius
+
+MANDATORY means "verify with fresh evidence", not "always run everything". Run
+the checks that could actually fail because of THIS diff. A check that cannot
+fail from the change is not evidence; it is wall-clock.
+
+Classify the diff first:
+
+**Test-only diff** — every changed file is a test, fixture, scanner or snapshot,
+and no file ships to a container or user. Then the test IS the subject, there is
+no runtime surface to diverge from, and the strongest available evidence is:
+
+1. the targeted test file(s), green;
+2. a mutation probe per behavioural claim (break it, confirm the intended check
+   goes red, revert) — this is the step that separates a real fix from a green
+   stamp, and it is cheap;
+3. one A/B of the affected test(s) on base vs branch.
+
+Do NOT run the full suite or the full validate chain for this class. Prefer the
+project's changed-files test selection (e.g. `vitest run --changed=origin/<base>`)
+plus any repo-wide scanner tests, which read the whole tree and so are not
+selected by `--changed`. Skip the sub-agent when the above fits in a handful of
+calls; run the probes inline and report them.
+
+**Everything else** — anything that reaches a container, a user, an API, a
+schema or a migration. Full Phase 3 below applies unchanged, including the
+container check: a green suite is not a claim that the running app works.
+
+Never invoke a formatter or generator as verification. Commands like
+`npm run format` and OpenAPI regeneration MUTATE the tree, producing unrelated
+churn you then have to revert and risk committing. Use the check-only variant
+(`--check`, `generate:check`, `lint`) instead.
+
 ### Step 1: Gather context for the sub-agent
 
 Before spawning, collect:


### PR DESCRIPTION
## Wat

Twee aanpassingen aan de verificatie-instructies in `/implement` en `/implement-epic`: schaal de verificatie naar wat de diff daadwerkelijk kan breken, en gebruik nooit een formatter of generator als bewijs.

## Waarom: "MANDATORY" werd gelezen als "draai alles"

Een check die niet kán falen door de diff onder review is geen bewijs, maar wachttijd. Die kosten betaal je bij elke run. `MANDATORY` betekent "verifieer met vers bewijs", niet "draai standaard het hele pak".

`/implement` krijgt daarom een classificatiestap vóór Phase 3:

- **Test-only diff** (alleen tests, fixtures, scanners, snapshots; niets dat naar een container of gebruiker gaat). De test ís hier het onderwerp; er is geen runtime-oppervlak dat kan afwijken. Sterkste beschikbare bewijs: de gerichte testbestanden groen, een mutatieprobe per gedragsclaim (breek het, bevestig dat de bedoelde check rood wordt, draai terug), en één A/B van de betrokken tests op base versus branch. Die mutatieprobe is precies wat een echte fix onderscheidt van een groene stempel, en hij is goedkoop.
- **Al het andere** (container, gebruiker, API, schema, migratie): Phase 3 blijft ongewijzigd van kracht, inclusief de container-check. Een groene suite is geen bewering dat de draaiende app werkt.

## Waarom: formatters en generators muteren de tree

`npm run format` en OpenAPI-regeneratie schrijven naar de working tree. Als je die als verificatie draait, produceer je churn die niets met het werk te maken heeft (geregenereerde specs verschillen vaak alleen in unicode-escaping) en die je daarna moet terugdraaien.

In `implement-epic` valt dat samen met de één plek waar de instructie zegt direct naar een gedeelde branch te committen. Dat is dus precies waar die churn onder een plausibel ogende commit message terechtkomt. Beide skills verwijzen nu naar de check-only varianten (`--check`, `generate:check`, `lint`), en `implement-epic` krijgt een expliciete stap om te inspecteren wát de validatie veranderde voordat je commit.

## Scope

Alleen documentatie: [skills/implement/SKILL.md](skills/implement/SKILL.md) en [skills/implement-epic/SKILL.md](skills/implement-epic/SKILL.md), 54 toegevoegde regels, geen bestaande regels gewijzigd of verwijderd. Geen code, geen gedragsverandering in scripts of hooks.
