### PR TITLE
fix(implement-epic): stop /tmp context files leaking between projects

### DIFF
--- a/bin/epic-prepare-context.sh
+++ b/bin/epic-prepare-context.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Copy CLAUDE.md files to /tmp/ for sub-agent consumption during epic implementation.
+# Copy CLAUDE.md files to a temp dir for sub-agent consumption during epic
+# implementation.
 #
 # Usage:
 #   epic-prepare-context.sh <epic-number> [project-dir]
@@ -10,7 +11,16 @@
 #   /tmp/epic-<project>-<number>-claude-frontend.md
 #   /tmp/epic-<project>-<number>-claude-backend.md
 #
-# Outputs the prefix to stdout for use in sub-agent prompts.
+# Outputs the prefix to stdout, and the list of copied sections to stderr.
+# Only mention a section in a sub-agent prompt if it was reported as copied:
+# a MISSING context file is harmless (the sub-agent reads the repo's CLAUDE.md
+# itself), but pointing an agent at a path holding ANOTHER project's doc makes
+# it treat foreign architecture as this project's. That is why each destination
+# is unlinked before the copy — a section that no longer exists in the project
+# must not resolve to an earlier run's file.
+#
+# Source paths differ per project (backend/CLAUDE.md vs backend/app/CLAUDE.md),
+# so each section tries several candidates and takes the first that exists.
 
 set -euo pipefail
 
@@ -22,25 +32,44 @@ fi
 EPIC_NUMBER="$1"
 PROJECT_DIR="${2:-$PWD}"
 
-# Derive project name from directory basename (lowercase)
-PROJECT_NAME=$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]')
-PREFIX="/tmp/epic-${PROJECT_NAME}-${EPIC_NUMBER}-claude"
+# Derive project name from directory basename (lowercase, non-alphanumerics
+# folded to '-') so the destination can never collide across projects.
+PROJECT_NAME=$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]' '-')
+PROJECT_NAME="${PROJECT_NAME%-}"
+PREFIX="${TMPDIR:-/tmp}/epic-${PROJECT_NAME}-${EPIC_NUMBER}-claude"
 
-# Copy CLAUDE.md files that exist
-copied=0
-for pair in "root:CLAUDE.md" "frontend:frontend/CLAUDE.md" "backend:backend/app/CLAUDE.md"; do
-  suffix="${pair%%:*}"
-  src="${pair#*:}"
-  dest="${PREFIX}-${suffix}.md"
-  if [[ -f "$PROJECT_DIR/$src" ]]; then
-    cp "$PROJECT_DIR/$src" "$dest"
-    copied=$((copied + 1))
-  fi
+# section:candidate[,candidate...] — first existing candidate wins.
+SECTIONS=(
+  "root:CLAUDE.md"
+  "frontend:frontend/CLAUDE.md,src/CLAUDE.md"
+  "backend:backend/CLAUDE.md,backend/app/CLAUDE.md"
+)
+
+copied=()
+for entry in "${SECTIONS[@]}"; do
+  section="${entry%%:*}"
+  dest="${PREFIX}-${section}.md"
+
+  # Drop any file left by an earlier run before deciding what to copy, so a
+  # section the project no longer has cannot resolve to stale content.
+  rm -f "$dest"
+
+  IFS=',' read -ra candidates <<< "${entry#*:}"
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$PROJECT_DIR/$candidate" ]]; then
+      cp "$PROJECT_DIR/$candidate" "$dest"
+      copied+=("${section} (${candidate})")
+      break
+    fi
+  done
 done
 
-if [[ $copied -eq 0 ]]; then
+if [[ ${#copied[@]} -eq 0 ]]; then
   echo "⚠️  No CLAUDE.md files found in $PROJECT_DIR" >&2
   exit 1
 fi
+
+echo "Context prepared from $PROJECT_DIR:" >&2
+printf '  %s\n' "${copied[@]}" >&2
 
 echo "$PREFIX"

--- a/bin/tests/test-epic-prepare-context.sh
+++ b/bin/tests/test-epic-prepare-context.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Tests for epic-prepare-context.sh.
+#
+# Usage:
+#   bin/tests/test-epic-prepare-context.sh
+#
+# Builds throwaway project trees in a temp dir and runs the script against them.
+# Nothing outside that temp dir is touched — including the destination files,
+# which are redirected into the temp dir via TMPDIR.
+#
+# The load-bearing part is WHICH file ends up at the backend destination.
+# A missing context file is harmless (the sub-agent reads the repo's CLAUDE.md
+# itself); a file from a DIFFERENT project at that path is actively misleading,
+# because the skill tells sub-agents to treat it as this project's architecture.
+# Cases 2, 5 and 6 exist for that specifically.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="${SCRIPT_UNDER_TEST:-$SCRIPT_DIR/../epic-prepare-context.sh}"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "script not found: $SCRIPT" >&2
+    exit 1
+fi
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+PASS=0; FAIL=0
+
+check() { # name expected actual
+    if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1))
+    else echo "  FAIL: $1 (expected '$2', got '$3')"; FAIL=$((FAIL+1)); fi
+}
+
+# Destinations land in $T/dest via TMPDIR so the real /tmp stays untouched.
+DEST="$T/dest"
+mkdir -p "$DEST"
+
+run() { # epic-number project-dir  -> prints the prefix, stderr on fd 2
+    TMPDIR="$DEST" bash "$SCRIPT" "$1" "$2"
+}
+
+# Build a project tree. Each extra arg is "relpath:marker" — the marker is
+# written into the file so we can tell whose doc ended up at a destination.
+newproject() { # name [relpath:marker ...]
+    local d="$T/$1"; shift
+    mkdir -p "$d"
+    local spec rel marker
+    for spec in "$@"; do
+        rel="${spec%%:*}"; marker="${spec#*:}"
+        mkdir -p "$d/$(dirname "$rel")"
+        printf '# %s\n\nArchitecture doc for %s.\n' "$marker" "$marker" > "$d/$rel"
+    done
+    echo "$d"
+}
+
+marker_of() { # file -> first-line marker, or "MISSING"
+    [[ -f "$1" ]] || { echo MISSING; return; }
+    head -1 "$1" | sed 's/^# //'
+}
+
+echo "== 1. PAM layout: backend/app/CLAUDE.md is copied =="
+P=$(newproject pam "CLAUDE.md:pam-root" "backend/app/CLAUDE.md:pam-backend")
+PREFIX=$(run 100 "$P")
+check "root copied"    pam-root    "$(marker_of "$PREFIX-root.md")"
+check "backend copied" pam-backend "$(marker_of "$PREFIX-backend.md")"
+
+echo "== 2. Otia layout: backend/CLAUDE.md is copied =="
+P=$(newproject otia "CLAUDE.md:otia-root" "backend/CLAUDE.md:otia-backend")
+PREFIX=$(run 200 "$P")
+check "root copied"    otia-root    "$(marker_of "$PREFIX-root.md")"
+check "backend copied" otia-backend "$(marker_of "$PREFIX-backend.md")"
+
+echo "== 3. frontend: src/CLAUDE.md is used when frontend/ has none =="
+P=$(newproject webapp "CLAUDE.md:web-root" "src/CLAUDE.md:web-src")
+PREFIX=$(run 300 "$P")
+check "frontend from src" web-src "$(marker_of "$PREFIX-frontend.md")"
+
+echo "== 4. first candidate wins when both backend paths exist =="
+P=$(newproject dual "CLAUDE.md:dual-root" \
+    "backend/CLAUDE.md:dual-backend-top" "backend/app/CLAUDE.md:dual-backend-app")
+PREFIX=$(run 400 "$P")
+check "backend/CLAUDE.md preferred" dual-backend-top "$(marker_of "$PREFIX-backend.md")"
+
+echo "== 5. no backend doc -> no backend destination file =="
+P=$(newproject frontonly "CLAUDE.md:front-root" "frontend/CLAUDE.md:front-fe")
+PREFIX=$(run 500 "$P")
+check "root copied"       front-root "$(marker_of "$PREFIX-root.md")"
+check "no backend file"   MISSING    "$(marker_of "$PREFIX-backend.md")"
+
+echo "== 6. stale destination from an earlier run is removed, not reused =="
+# Same project + same epic number, but the backend doc is gone the second time.
+# Without an unlink the first run's copy survives and the skill points
+# sub-agents at a doc the project no longer has.
+P=$(newproject churn "CLAUDE.md:churn-root" "backend/CLAUDE.md:churn-backend-v1")
+PREFIX=$(run 600 "$P")
+check "backend present on first run" churn-backend-v1 "$(marker_of "$PREFIX-backend.md")"
+rm "$P/backend/CLAUDE.md"
+PREFIX=$(run 600 "$P")
+check "stale backend removed" MISSING "$(marker_of "$PREFIX-backend.md")"
+
+echo "== 7. destinations are namespaced per project =="
+A=$(newproject alpha "CLAUDE.md:alpha-root" "backend/CLAUDE.md:alpha-backend")
+B=$(newproject beta  "CLAUDE.md:beta-root")
+PREFIX_A=$(run 700 "$A")
+PREFIX_B=$(run 700 "$B")
+check "different prefixes per project" different \
+    "$([[ "$PREFIX_A" != "$PREFIX_B" ]] && echo different || echo same)"
+check "project A backend untouched by B" alpha-backend "$(marker_of "$PREFIX_A-backend.md")"
+check "project B has no backend leak"    MISSING       "$(marker_of "$PREFIX_B-backend.md")"
+
+echo "== 8. reports which docs were copied so a miss is visible =="
+P=$(newproject reported "CLAUDE.md:rep-root" "backend/CLAUDE.md:rep-backend")
+ERR=$(TMPDIR="$DEST" bash "$SCRIPT" 800 "$P" 2>&1 >/dev/null)
+check "names root"        yes "$(grep -q root    <<<"$ERR" && echo yes || echo no)"
+check "names backend"     yes "$(grep -q backend <<<"$ERR" && echo yes || echo no)"
+check "omits frontend"    yes "$(grep -q frontend <<<"$ERR" && echo no || echo yes)"
+
+echo "== 9. no CLAUDE.md at all -> non-zero exit =="
+P=$(newproject empty)
+if TMPDIR="$DEST" bash "$SCRIPT" 900 "$P" >/dev/null 2>&1; then rc=0; else rc=1; fi
+check "exits non-zero" 1 "$rc"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -84,13 +84,15 @@ Issues within the same wave are implemented sequentially (each needs the branch 
 
 ### Step 4: Prepare project context for sub-agents
 
-Copy all CLAUDE.md files to `/tmp/` so sub-agents can lazy-load them (avoids embedding 20-30 KB of identical context in every sub-agent prompt):
+Copy the project's CLAUDE.md files to a temp location so sub-agents can lazy-load them (avoids embedding 20-30 KB of identical context in every sub-agent prompt):
 
 ```bash
-cp CLAUDE.md /tmp/epic-claude-root.md
-cp frontend/CLAUDE.md /tmp/epic-claude-frontend.md 2>/dev/null || true
-cp backend/app/CLAUDE.md /tmp/epic-claude-backend.md 2>/dev/null || true
+~/.claude/bin/epic-prepare-context.sh $ARGUMENTS
 ```
+
+The script prints the destination prefix on stdout — store it as `context_prefix` (e.g. `/tmp/epic-otia-632-claude`). On stderr it lists which sections it copied and from which source path, because doc layouts differ per project (`backend/CLAUDE.md` vs `backend/app/CLAUDE.md`, `frontend/CLAUDE.md` vs `src/CLAUDE.md`).
+
+**Only list a section in a sub-agent prompt if the script reported copying it.** A missing context file is harmless — the sub-agent reads the repo's CLAUDE.md itself. Pointing an agent at a path that holds nothing, or worse another project's doc, makes it treat foreign architecture as this project's. The prefix is namespaced per project and epic, and stale destinations are cleared on every run, so cross-project contamination cannot occur through this path.
 
 Also read the root CLAUDE.md yourself to extract the **one-line tech stack summary** and **test/validation commands** — store these as `project_summary` (max 5 lines). This small summary goes into every sub-agent prompt; the full CLAUDE.md files are read by the sub-agent on demand.
 
@@ -222,10 +224,10 @@ Body: <full issue body>
 <project_summary — max 5 lines: tech stack, test command, validation command>
 
 Project policies are in these files — read them BEFORE writing code:
-- /tmp/epic-claude-root.md (project overview, naming conventions, dev commands)
-- /tmp/epic-claude-frontend.md (frontend architecture — read if modifying frontend)
-- /tmp/epic-claude-backend.md (backend architecture — read if modifying backend)
-Read only the files relevant to your issue. Do NOT skip this step.
+- <context_prefix>-root.md (project overview, naming conventions, dev commands)
+- <context_prefix>-frontend.md (frontend architecture — read if modifying frontend)
+- <context_prefix>-backend.md (backend architecture — read if modifying backend)
+List only the sections Phase 0 reported as copied. Read only the files relevant to your issue. Do NOT skip this step.
 
 ## Branch Setup
 - Feature branch: <feature_branch>
@@ -362,8 +364,8 @@ Body: <full issue body>
 <project_summary — max 5 lines: tech stack, test command, validation command>
 
 Project policies are in these files — read them BEFORE starting your audit:
-- /tmp/epic-claude-root.md (project overview, naming conventions)
-- /tmp/epic-claude-backend.md (backend architecture, security patterns)
+- <context_prefix>-root.md (project overview, naming conventions)
+- <context_prefix>-backend.md (backend architecture, security patterns)
 Read only the files relevant to your audit domain. Do NOT skip this step.
 
 ## Audit Instructions
@@ -618,9 +620,9 @@ Spawn a background agent:
 You are verifying the feature branch `<feature_branch>` after all sub-issues have been merged.
 
 Project policies are in these files — read them BEFORE starting:
-- /tmp/epic-claude-root.md (project overview, dev commands)
-- /tmp/epic-claude-backend.md (backend architecture — if backend changes)
-- /tmp/epic-claude-frontend.md (frontend architecture — if frontend changes)
+- <context_prefix>-root.md (project overview, dev commands)
+- <context_prefix>-backend.md (backend architecture — if backend changes)
+- <context_prefix>-frontend.md (frontend architecture — if frontend changes)
 
 ### Step 1: Run project validation
 
@@ -706,7 +708,7 @@ Spawn a background agent:
 You are verifying that the application works at runtime after all sub-issues for epic #<epic_number> have been merged into `<feature_branch>`.
 
 Project policies are in these files — read them BEFORE starting:
-- /tmp/epic-claude-root.md (project overview, dev commands)
+- <context_prefix>-root.md (project overview, dev commands)
 
 ### Step 1: Rebuild containers if dependencies changed
 
@@ -822,8 +824,8 @@ RESULT: PASS/FAIL/SKIP — <details>
 You are writing and running a minimal Playwright smoke test to verify that the UI changes from epic #<epic_number> work at runtime.
 
 Project policies are in these files — read them BEFORE starting:
-- /tmp/epic-claude-root.md (project overview)
-- /tmp/epic-claude-frontend.md (frontend architecture, testing patterns)
+- <context_prefix>-root.md (project overview)
+- <context_prefix>-frontend.md (frontend architecture, testing patterns)
 
 ### Step 1: Determine the epic's UI domain
 


### PR DESCRIPTION
Closes #47

## Probleem

`implement-epic` Phase 0 kopieerde project-CLAUDE.md's naar vaste `/tmp`-paden
(`/tmp/epic-claude-backend.md`). Drie dingen stapelden op elkaar: het bronpad
was hardcoded op PAM's layout (`backend/app/CLAUDE.md`), `|| true` maakte een
misser onzichtbaar, en de vaste doelnaam is projectoverstijgend. Gevolg: een
epic in Otia liet sub-agents PAM's backend-doc lezen als "de architectuur van
dit project".

## Wijzigingen

`bin/epic-prepare-context.sh` bestond al met projectgenamespacete doelnamen,
maar SKILL.md gebruikte het niet en het script had bug 1 nog. Beide opgelost:

1. **Kandidaatpaden per sectie** — backend probeert `backend/CLAUDE.md` dan
   `backend/app/CLAUDE.md`; frontend probeert `frontend/CLAUDE.md` dan
   `src/CLAUDE.md`. Eerste treffer wint.
2. **Namespace per project + epic** — prefix is `epic-<project>-<nr>-claude`,
   met niet-alfanumerieke tekens in de projectnaam gevouwen naar `-`.
   Contaminatie tussen projecten is hiermee structureel uitgesloten.
3. **Stale bestanden worden gewist** — elke bestemming wordt ge-unlinkt vóór de
   kopie, dus een sectie die het project niet meer heeft kan niet naar de inhoud
   van een vorige run resolven.
4. **De misser is zichtbaar** — het script rapporteert op stderr welke secties
   het kopieerde en uit welk bronpad. SKILL.md instrueert nu expliciet: noem
   alleen secties die als gekopieerd zijn gerapporteerd.
5. **SKILL.md aangesloten** — het inline `cp`-blok is vervangen door een aanroep
   van het script; alle zes hardcoded `/tmp/epic-claude-*.md` verwijzingen op de
   vijf sub-agent-promptsites gebruiken nu `<context_prefix>-*.md`.

De fix zit in het script en niet inline in SKILL.md, omdat een bash-blok in een
markdown-bestand niet testbaar is.

## Verificatie

Deze diff raakt geen container, API, schema of migratie; verificatie is
dienovereenkomstig gescoped op de shell-laag.

- **Tests: 17/17** — nieuwe suite `bin/tests/test-epic-prepare-context.sh`,
  in de stijl van de bestaande hook-suite (throwaway trees, `TMPDIR` naar een
  temp-dir zodat de echte `/tmp` onaangeroerd blijft). Dekt beide backend-layouts,
  de `src/` frontend-fallback, first-match-wins, stale-verwijdering, namespacing
  en de rapportage.
- **A/B: base 10/17, branch 17/17.**
- **Mutatieproeven: alle drie de guards dragen.** Unlink weghalen → 1 rood;
  terug naar alleen `backend/app` → 5 rood; namespace weghalen → 2 rood,
  waaronder precies het lek uit de issue (project B's run wist A's context).
- **shellcheck: exit 0** op beide scripts.
- **Echte layouts:** PAM valt correct door naar `backend/app/CLAUDE.md`;
  `PAM` en `PAM-dev1` krijgen bij hetzelfde epicnummer verschillende prefixes.

## Acceptatiecriteria

| # | Criterium | Bewijs | Status |
|---|-----------|--------|--------|
| 1 | Glob over plausibele paden | cases 2, 3, 4; mutatie B → 5 rood | ✅ |
| 2 | Doelnaam per project genamespaced | case 7; mutatie C → 2 rood | ✅ |
| 3 | `\|\| true` weg / misser expliciet | cases 5, 8; stderr-rapportage | ✅ |

## Known Issues

Geen.
