### PR TITLE
docs: generalize project-specific references in skills and rules

### DIFF
--- a/bin/tests/test-epic-prepare-context.sh
+++ b/bin/tests/test-epic-prepare-context.sh
@@ -60,17 +60,17 @@ marker_of() { # file -> first-line marker, or "MISSING"
     head -1 "$1" | sed 's/^# //'
 }
 
-echo "== 1. PAM layout: backend/app/CLAUDE.md is copied =="
-P=$(newproject pam "CLAUDE.md:pam-root" "backend/app/CLAUDE.md:pam-backend")
+echo "== 1. nested layout: backend/app/CLAUDE.md is copied =="
+P=$(newproject nested "CLAUDE.md:nested-root" "backend/app/CLAUDE.md:nested-backend")
 PREFIX=$(run 100 "$P")
-check "root copied"    pam-root    "$(marker_of "$PREFIX-root.md")"
-check "backend copied" pam-backend "$(marker_of "$PREFIX-backend.md")"
+check "root copied"    nested-root    "$(marker_of "$PREFIX-root.md")"
+check "backend copied" nested-backend "$(marker_of "$PREFIX-backend.md")"
 
-echo "== 2. Otia layout: backend/CLAUDE.md is copied =="
-P=$(newproject otia "CLAUDE.md:otia-root" "backend/CLAUDE.md:otia-backend")
+echo "== 2. flat layout: backend/CLAUDE.md is copied =="
+P=$(newproject flat "CLAUDE.md:flat-root" "backend/CLAUDE.md:flat-backend")
 PREFIX=$(run 200 "$P")
-check "root copied"    otia-root    "$(marker_of "$PREFIX-root.md")"
-check "backend copied" otia-backend "$(marker_of "$PREFIX-backend.md")"
+check "root copied"    flat-root    "$(marker_of "$PREFIX-root.md")"
+check "backend copied" flat-backend "$(marker_of "$PREFIX-backend.md")"
 
 echo "== 3. frontend: src/CLAUDE.md is used when frontend/ has none =="
 P=$(newproject webapp "CLAUDE.md:web-root" "src/CLAUDE.md:web-src")

--- a/rules/database-concurrency.md
+++ b/rules/database-concurrency.md
@@ -6,16 +6,16 @@ paths: "**/database/**, **/db/**, **/models/**, **/repositories/**, **/*session*
 # Database Concurrency
 
 Pick one DB-access lane and stay in it. Mixing sync and async is the trap, not
-either one on its own. (Lesson A8 — PAM.)
+either one on its own.
 
 ## Sync vs async: choose deliberately, never by cargo-cult
 
 - **Sync engine → `def` route handlers, never `async def`** for DB-touching routes.
   FastAPI runs `def` handlers in a threadpool (no event-loop blocking). A **sync**
   `Session` inside an `async def` route blocks the event loop on *every query* — the
-  most common FastAPI footgun. PAM shipped 87 `async def` routes holding a sync
-  `Session`, doing synchronous DB work with no `await` in the body: pure overhead and
-  a latent outage, chosen by copying FastAPI examples, never decided.
+  most common FastAPI footgun. One project shipped 87 `async def` routes holding a
+  sync `Session`, doing synchronous DB work with no `await` in the body: pure overhead
+  and a latent outage, chosen by copying FastAPI examples, never decided.
 - **`async def` only when there is real async I/O** — an actual `await` on an async
   client/SDK. Don't propagate `async` through services/helpers that do no real I/O;
   async that awaits nothing is cost without benefit.
@@ -31,7 +31,7 @@ either one on its own. (Lesson A8 — PAM.)
 ## Pool hardening is foundation work, not incident response
 
 Bake these into the engine setup from day one — don't wait for the outage that
-teaches them (PAM learned via a 40-minute stuck-pool outage):
+teaches them (one project learned via a 40-minute stuck-pool outage):
 
 - `pool_pre_ping=True` — replace dead connections before handing them out; log the
   replacement so degrading pool health is visible early, not discovered mid-outage.

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -90,7 +90,7 @@ Copy the project's CLAUDE.md files to a temp location so sub-agents can lazy-loa
 ~/.claude/bin/epic-prepare-context.sh $ARGUMENTS
 ```
 
-The script prints the destination prefix on stdout — store it as `context_prefix` (e.g. `/tmp/epic-otia-632-claude`). On stderr it lists which sections it copied and from which source path, because doc layouts differ per project (`backend/CLAUDE.md` vs `backend/app/CLAUDE.md`, `frontend/CLAUDE.md` vs `src/CLAUDE.md`).
+The script prints the destination prefix on stdout — store it as `context_prefix` (e.g. `/tmp/epic-<project>-632-claude`). On stderr it lists which sections it copied and from which source path, because doc layouts differ per project (`backend/CLAUDE.md` vs `backend/app/CLAUDE.md`, `frontend/CLAUDE.md` vs `src/CLAUDE.md`).
 
 **Only list a section in a sub-agent prompt if the script reported copying it.** A missing context file is harmless — the sub-agent reads the repo's CLAUDE.md itself. Pointing an agent at a path that holds nothing, or worse another project's doc, makes it treat foreign architecture as this project's. The prefix is namespaced per project and epic, and stale destinations are cleared on every run, so cross-project contamination cannot occur through this path.
 
@@ -710,6 +710,23 @@ You are verifying that the application works at runtime after all sub-issues for
 Project policies are in these files — read them BEFORE starting:
 - <context_prefix>-root.md (project overview, dev commands)
 
+### Step 0: Find the project's own commands
+
+This step is project-specific — never guess a container name or a script path.
+Read the root CLAUDE.md and the compose file to establish, before running
+anything:
+
+- `api_container` — the service/container running the API (`docker compose ps`,
+  or the service key in `docker-compose.yml`)
+- `restart_cmd` — how this project restarts its stack. Many projects wrap this
+  in `stop.sh`/`start.sh` scripts, because a plain `docker compose restart`
+  leaves services behind a `depends_on` health gate untouched. Prefer the
+  project's own scripts where they exist
+- `login_script` — the project's API login helper, if it has one
+
+If a project defines none of these, skip the steps below that depend on it and
+report SKIP with the reason. A step that cannot be run is not a failure.
+
 ### Step 1: Rebuild containers if dependencies changed
 
 Check if dependency files were modified:
@@ -718,10 +735,9 @@ Check if dependency files were modified:
 git diff develop..<feature_branch> --name-only | grep -E "(package\.json|package-lock\.json|requirements\.txt|pyproject\.toml|uv\.lock)"
 ```
 
-If any dependency file changed:
-- Frontend: `cd backend/docker && ./stop.sh && ./start.sh`
-- Backend only: `docker restart pam_api`
-Wait for containers to be healthy: `~/.claude/bin/wait-for-healthy.sh pam_api`
+If any dependency file changed, run `<restart_cmd>` — a dependency change needs
+a rebuild, not a plain restart. Then wait for health:
+`~/.claude/bin/wait-for-healthy.sh <api_container>`
 
 ### Step 2: Container health check
 
@@ -730,7 +746,7 @@ Wait for containers to be healthy: `~/.claude/bin/wait-for-healthy.sh pam_api`
 ```
 
 If containers are down or unhealthy:
-1. Run `cd backend/docker && ./stop.sh && ./start.sh`
+1. Run `<restart_cmd>`
 2. Wait 15 seconds, re-check
 3. After 1 failed retry: report failure but continue
 
@@ -740,19 +756,21 @@ If containers are down or unhealthy:
 ~/.claude/bin/smoke-test.sh [base-url] [--health-token TOKEN]
 ```
 
-### Step 4: Migration check (if alembic detected)
+### Step 4: Migration check (if a migration tool is detected)
 
-- Run `docker exec pam_api alembic current` and verify no errors
-- Check `docker logs pam_api --tail 20` for migration failures
+- Run the project's "current revision" command in the API container (for
+  alembic: `docker exec <api_container> alembic current`) and verify no errors
+- Check `docker logs <api_container> --tail 20` for migration failures
 - If migrations failed: investigate and fix
 
 ### Step 5: Login smoke test
 
-Use the project's API login script to verify a test account can log in:
+If the project has a login script, use it to verify a test account can log in:
 ```bash
-./scripts/api-login.sh admin
+<login_script> admin
 ```
 If it fails with 502/500: the API is broken — investigate container logs.
+If the project has no such script, report SKIP.
 
 ### Step 6: Report
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -27,9 +27,9 @@ MUST use ~/.claude/bin/git-find-base-branch for base branch detection for the PR
 
 1. Fetch issue details: `~/.claude/bin/gh-save.sh /tmp/issue-$ARGUMENTS.json issue view $ARGUMENTS --json title,body,labels`, then use the Read tool to read it
 2. **Check for linked Sentry issues** in the issue body:
-   * Look for Sentry issue references like `PAM-BACKEND-X`, Sentry URLs, or "Sentry Issues" sections
+   * Look for Sentry issue references — short IDs of the form `<PROJECT>-<PLATFORM>-<SUFFIX>`, Sentry URLs, or "Sentry Issues" sections
    * If found, note the Sentry issue IDs — these will be referenced in commit messages and the PR body for automatic resolution
-   * Store as a list, e.g. `SENTRY_ISSUES=["PAM-BACKEND-G", "PAM-BACKEND-H"]`
+   * Store as a list, e.g. `SENTRY_ISSUES=["MYAPP-BACKEND-G", "MYAPP-BACKEND-H"]`
 3. Read AND verify understanding of existing code:
    * Read all CLAUDE.md files (root, frontend, backend if they exist)
    * Read the ACTUAL source files you plan to modify
@@ -80,7 +80,7 @@ STOP HERE and ask for confirmation before proceeding to implementation.
    * Remove duplication, improve naming if needed
    * Run tests again to confirm nothing broke
    * Commit: `~/.claude/bin/git-commit.sh "descriptive message for this step"`
-   * If SENTRY_ISSUES were found in Phase 1, add `Fixes <ID>` to the **final commit only** (the last step before PR creation), e.g.: `~/.claude/bin/git-commit.sh "final step description" "" "Fixes PAM-BACKEND-G" "Fixes PAM-BACKEND-H"`
+   * If SENTRY_ISSUES were found in Phase 1, add `Fixes <ID>` to the **final commit only** (the last step before PR creation), e.g.: `~/.claude/bin/git-commit.sh "final step description" "" "Fixes MYAPP-BACKEND-G" "Fixes MYAPP-BACKEND-H"`
 
 4. **Move on — Focus shifts to the next step**
    * Do not revisit completed steps unless a later test breaks them
@@ -215,11 +215,15 @@ If findings with severity > INFO:
 - Max 2 iterations — remaining findings go into the PR body as "Known Issues"
 
 ### Step F: API smoke test (skip if has_backend_endpoints = false)
-1. Restart API container: `docker restart pam_api`, then wait for it to come back up: `~/.claude/bin/wait-for-healthy.sh pam_api`
-2. Seed E2E accounts if needed: `npm run db:seed:e2e`
-3. Login: `./scripts/api-login.sh premium` then read `/tmp/pam-token.txt`
+First establish the project's own names — read the root CLAUDE.md and the
+compose file for the API container, the restart command and the login helper.
+Never guess a container name or script path; if the project defines none, skip
+this step and report SKIP with the reason.
+1. Restart the API container, then wait for it to come back up: `~/.claude/bin/wait-for-healthy.sh <api_container>`
+2. Seed test accounts if the project has a seed command
+3. Log in with the project's login helper and capture the token it writes
 4. Call each new/modified endpoint, verify 2xx + correct JSON structure
-5. On 500: check `docker logs pam_api --tail 30`, fix root cause, re-run
+5. On 500: check `docker logs <api_container> --tail 30`, fix root cause, re-run
 
 ## Execute — do not describe or delegate
 
@@ -270,7 +274,7 @@ Before proceeding to PR creation:
    - Test checklist (test counts from the verification sub-agent's TESTS line)
    - If `KNOWN_ISSUES` from Phase 3 is not "none": add a `## Known Issues` section listing them
    - If `AC_UNVERIFIED` from Phase 3 is not "none": add a `## Manual Review Needed` section listing the UNVERIFIED criteria
-   - If SENTRY_ISSUES were found in Phase 1, add a `## Sentry` section: `Resolves: PAM-BACKEND-G, PAM-BACKEND-H`
+   - If SENTRY_ISSUES were found in Phase 1, add a `## Sentry` section: `Resolves: MYAPP-BACKEND-G, MYAPP-BACKEND-H`
 3. Push + create PR in one command:
    `~/.claude/bin/git-push-pr-merge.sh --base <base-branch> --title "<concise description>" --body-file /tmp/pr-body.md --no-merge`
    `--no-merge` means the CI gate is skipped — the PR is left open for human review regardless of check status

--- a/skills/promote/SKILL.md
+++ b/skills/promote/SKILL.md
@@ -14,7 +14,7 @@ Move a proven project-local pattern to the shared toolkit (`claude-code-toolkit`
 ## Input
 
 The argument is one of: `$ARGUMENTS`
-- A path to a script (e.g. `scripts/pam-login.sh`)
+- A path to a script (e.g. `scripts/api-login.sh`)
 - A procedure name from CLAUDE.md (e.g. "FastAPI session auth")
 - A toolkit proposal file (e.g. `~/.claude/toolkit-proposals/fastapi-session-login.md`)
 
@@ -87,10 +87,10 @@ Before (in project repo):
 After (in project repo):
 ```bash
 #!/usr/bin/env bash
-# PAM login — wraps toolkit's fastapi-session-login
+# Project login — wraps toolkit's fastapi-session-login
 source .env
 ~/.claude/bin/fastapi-session-login.sh \
-  "http://localhost:8000" "$PAM_DEBUG_USER" "$PAM_DEBUG_PASS"
+  "http://localhost:8000" "$DEBUG_USER" "$DEBUG_PASS"
 ```
 
 New (in toolkit repo):
@@ -118,7 +118,7 @@ After (in project CLAUDE.md):
 ## Learned Procedures
 ### FastAPI Session Auth
 See ~/.claude/skills/claude-code-toolkit/claude-md/procedures/fastapi-session-auth.md
-Project-specific: base URL is http://localhost:8000, credentials in .env as PAM_DEBUG_USER/PAM_DEBUG_PASS
+Project-specific: base URL is http://localhost:8000, credentials in .env as DEBUG_USER/DEBUG_PASS
 ```
 
 ## Phase 5: Update References

--- a/skills/release-pr/SKILL.md
+++ b/skills/release-pr/SKILL.md
@@ -44,9 +44,9 @@ not do before?**
 
 | Bump | When | Real example |
 |---|---|---|
-| `major` | breaking change consumers must react to — removed/renamed route or response field, a migration dropping data still in use, a config rename with no fallback | (none yet in this repo) |
-| `minor` | new capability that did not exist in the previous tag | v1.9.0 — registration kill-switch, unified seen-tracking |
-| `patch` | fixes, refactors, docs, dependency bumps, tests. No new capability | v1.7.1 — backups produced archives that could not be restored; "fixes a path that was already supposed to work" |
+| `major` | breaking change consumers must react to — removed/renamed route or response field, a migration dropping data still in use, a config rename with no fallback | a response field consumers still read is renamed with no fallback |
+| `minor` | new capability that did not exist in the previous tag | a kill-switch that lets an operator disable registration at runtime |
+| `patch` | fixes, refactors, docs, dependency bumps, tests. No new capability | backups produced archives that could not be restored; "fixes a path that was already supposed to work" |
 
 Mixed batch → the highest bump present wins. A batch with one new feature and
 twelve fixes is `minor`.
@@ -99,10 +99,10 @@ Headings describe **the problem solved**, not the PR. Past releases use
 
 - **Operator note** — anything a human must do around the deploy: renamed env
   vars (with an old→new table), a new variable to set, a feature that ships
-  *off* and needs turning on. Include the restart caveat: use `stop.sh`/
-  `start.sh`, since a plain `docker compose restart` leaves `pam_api` untouched
-  behind its `depends_on` health gate, so a new env value never reaches the
-  process.
+  *off* and needs turning on. Include the restart caveat where it applies: with
+  a `depends_on` health gate, a plain `docker compose restart` can leave a
+  service untouched, so a new env value never reaches the process — use the
+  project's own stop/start scripts instead.
 - **Migration note** — one bullet per migration: what it does, whether it is
   additive or destructive, whether it is idempotent. Call out any drop
   explicitly and say why it is safe (e.g. expand/contract split across two
@@ -120,8 +120,8 @@ each with a **specific justification for this batch** — not a bare `[x]`:
 
 ```
 - [x] No destructive ops added without a second barrier — `20260812002` drops
-      `persons.waves_last_viewed_at`, deliberately split into its own revision
-      so it runs only after the data moved to `match_actions.seen_at`
+      `<table>.<old_column>`, deliberately split into its own revision so it
+      runs only after the data moved to `<other_table>.<new_column>`
 ```
 
 If an item genuinely does not apply, say why it does not apply. Never tick a
@@ -134,8 +134,8 @@ Apply the label **at creation**, so `semver-check` sees exactly one:
 ```bash
 gh pr create --repo OWNER/NAME --base master --head develop \
   --label "release:minor" \
-  --title "release: v1.9.0 — registration kill-switch (#2480), unified seen-tracking (#2466), bare-domain vhosts (#2369)" \
-  --body-file /tmp/pam-pr-body-release-190.md
+  --title "release: v1.9.0 — <headline item> (#123), <second item> (#124), <third item> (#125)" \
+  --body-file /tmp/<project>-pr-body-release-190.md
 ```
 
 Title format: `release: vX.Y.Z — <2-3 headline items with issue numbers>`.


### PR DESCRIPTION
Closes #16

Deze repo is publiek, maar `skills/` en `rules/` bevatten verwijzingen naar privé-projecten: containernamen, Sentry ID-prefixes, paden naar loginscripts, kolomnamen uit een schema en features uit een releasegeschiedenis.

De grep leverde 7 bestanden op, in drie soorten die elk een andere fix nodig hadden.

## 1. Placeholders waar de naam willekeurig was

Hernoemd naar neutrale waarden:

- `skills/promote/SKILL.md` — `PAM_DEBUG_USER`/`PAM_DEBUG_PASS` → `DEBUG_USER`/`DEBUG_PASS`, `scripts/pam-login.sh` → `scripts/api-login.sh`
- `skills/implement-epic/SKILL.md` — `/tmp/epic-otia-632-claude` → `/tmp/epic-<project>-632-claude`
- `bin/tests/test-epic-prepare-context.sh` — de fixtures heten nu `nested` en `flat`, naar de doclayout die ze testen, in plaats van naar de projecten die die layout toevallig gebruiken. Dat leest ook beter als testnaam: de test gaat over `backend/app/CLAUDE.md` versus `backend/CLAUDE.md`, niet over wie dat gebruikt.

## 2. Hardgecodeerde operationele defaults

Dit was de echte bug, niet alleen een lek. `docker restart pam_api` en `./scripts/api-login.sh` in een publieke skill zijn geen gelekte naam maar een instructie die in elk ander project faalt of de verkeerde container raakt.

`implement` (Step F) en `implement-epic` (Phase Final, Step 2) stellen nu eerst vast wat het project zelf gebruikt — containernaam, restart-commando, login-helper — uit de root CLAUDE.md en het compose-bestand, en rapporteren SKIP als een project ze niet definieert. Een stap die niet te draaien is, is geen mislukking.

De restart-caveat blijft behouden, maar generiek: achter een `depends_on` health gate laat een kale `docker compose restart` services ongemoeid, dus een nieuwe env-waarde bereikt het proces niet. Waar een project eigen stop/start-scripts heeft, gebruik die.

## 3. Attributie in lessen

`rules/database-concurrency.md`: "Lesson A8 — PAM" eruit, de 87 `async def`-routes en de 40-minuten stuck-pool outage blijven staan. Die cijfers dragen de les; welk project ze opliep niet. Dit is precies wat stap 2 van #16 voorschrijft.

## Wat bewust niet is gedaan

`release-pr` is maar half opgeschoond. De identifiers zijn weg (`pam_api`, `persons.waves_last_viewed_at`, `match_actions.seen_at`, #2480/#2466/#2369), maar de skill is geschreven tegen één project z'n CI en releasegeschiedenis: `semver-tag.yml`, `deploy-staging`, het `agent-authored`-label, v1.5.0–v1.9.0. Dat volledig generiek maken is een herschrijving, geen sweep, en hoort in een eigen issue.

De derde AC van #16 — de strip-instructie in `/promote` en `/retro` — bleek al aanwezig (`promote/SKILL.md:45`, `retro/SKILL.md:184`) en is uitgebreider dan het issue vraagt. Daar was geen wijziging nodig.

## Verificatie

- Grep op de projectidentifiers over `skills/`, `rules/`, `claude-md/` en `bin/`: geen treffers. Wat overblijft is `stripe-testing` dat hoofdletterongevoelig op `pam` matcht, plus vendor-URL's en generieke localhost-poorten.
- Bredere sweep op `ImperialAutomation`, `/home/jan`, product-URL's: alleen vendordocumentatie en upstream `.system/`-skills.
- `bash bin/tests/test-epic-prepare-context.sh` — 17/17 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
