### PR TITLE
implement skills: explicit worktree parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 
 | Script | Usage | Description |
 |--------|-------|-------------|
-| `git-find-base-branch` | `git-find-base-branch [repo-dir]` | Detect the base branch of the current branch, or of the worktree at `repo-dir` |
+| `git-find-base-branch` | `git-find-base-branch [--repo DIR \| repo-dir]` | Detect the base branch of the current branch, or of the given worktree |
 | `git-resolve-worktree.sh` | `git-resolve-worktree.sh [--issue N] [hint]` | Resolve a worktree hint to one absolute path. Refuses to guess: zero or several matches exit non-zero and list the candidates with their branches |
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
 | `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents). Can print `ok N files changed` without committing — see [failure modes](docs/git-script-failure-modes.md) |
+| `git-verify.sh` | `git-verify.sh [--repo DIR \| repo-dir] [--base B] [--alembic]` | Read-only status snapshot (branch, uncommitted, recent commits, vs upstream, stashes, worktrees) in one call |
 | `git-push-pr-merge.sh` | `git-push-pr-merge.sh [--repo DIR] [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). `--repo` targets a worktree instead of the current directory. Repos without CI need `--no-ci-wait`. Creates the PR itself, so `gh pr create` hooks do not fire — see [failure modes](docs/git-script-failure-modes.md) |
 
 `git-resolve-worktree.sh` exists because an agent's working directory resets
@@ -147,14 +148,32 @@ stdout**, so a `$(...)` capture cannot silently become a guess. With no argument
 and nothing to detect it prints the current worktree, leaving single-worktree
 projects exactly as they were.
 
-`git-find-base-branch <dir>`, `git-commit.sh --repo`, `git-diff-base.sh --repo`
-and `git-push-pr-merge.sh --repo` all take that same path, for the same reason:
-without it they read the start directory and act on the wrong tree.
-`git-push-pr-merge.sh` is the one with real teeth — it pushes, opens a PR, and on
-merge runs `checkout` and `branch -D`, so a wrong target is destructive to a tree
-nobody is watching, so it validates the path itself and refuses before pushing;
-the others fail loudly through git. None of them fall back to the caller's
-directory.
+**`--repo` is the convention for every script that selects a git worktree**:
+`git-commit.sh`, `git-diff-base.sh`, `git-push-pr-merge.sh`, `git-verify.sh` and
+`git-find-base-branch` all take that same path, for the same reason — without it
+they read the start directory and act on the wrong tree. `git-push-pr-merge.sh`
+is the one with real teeth: it pushes, opens a PR, and on merge runs `checkout`
+and `branch -D`, so a wrong target is destructive to a tree nobody is watching.
+It validates the path itself and refuses before pushing; the others fail loudly
+through git. None of them fall back to the caller's directory.
+
+Deliberately *not* `-C`, despite the resemblance to `git -C`. That flag means
+"run as if git was started in `<path>`" — a chdir, which is why `git -C ""` is a
+no-op and why multiple `-C`s stack relative to each other. These scripts do
+something narrower: select a worktree, and refuse a path that is not one.
+Reusing the letter for different semantics is the wrong kind of consistency, and
+a single letter buys nothing when the caller is an agent rather than a typist.
+
+`git-verify.sh` and `git-find-base-branch` also still accept the path
+positionally, so existing calls keep working. Naming the same tree twice is fine;
+naming two different ones is an error rather than a silent pick, because the
+loser is a tree the caller believed they were asking about.
+
+Scripts that take a *scan path* rather than a worktree keep their positional
+argument: `deps-audit.sh`, `secret-scan.sh`, `env-audit.sh`, `docker-audit.sh`,
+`docker-health-check.sh` and `epic-prepare-context.sh`. `secret-scan.sh
+~/Downloads` is a meaningful thing to ask for, and calling that `--repo` would
+misdescribe the argument.
 
 ### Project audits
 
@@ -226,6 +245,7 @@ claude-code-toolkit/
 │   ├── batch-issue-view.sh    ← fetch multiple issues as JSON array
 │   ├── batch-issue-status.sh  ← fetch issue status as JSON array
 │   ├── git-find-base-branch   ← detect base branch (of a given worktree)
+│   ├── git-verify.sh          ← read-only git status snapshot in one call
 │   ├── git-resolve-worktree.sh ← resolve a worktree hint to one absolute path
 │   ├── git-cleanup-merged-branch.sh ← cleanup after PR merge
 │   ├── git-commit.sh               ← commit via temp file (sub-agent safe)

--- a/README.md
+++ b/README.md
@@ -140,13 +140,26 @@ session's branch, carrying that session's staged files, and exit 0.
 
 The script turns a short hint into the one absolute path that every following
 command must carry (`git -C <path>`, `git-commit.sh --repo <path>`, absolute
-Read/Edit paths). `--issue N` finds the worktree on branch `issue-N-*`, so resumed
-work needs no argument at all; otherwise a case-insensitive substring of the path
-is enough. Ambiguity is the interesting case: several matches, or none, exit
+Read/Edit paths). A hint is an exact worktree name, a unique case-insensitive
+substring of its path, or an absolute path.
+
+**An exact name beats a substring.** Worktree siblings are conventionally named
+by suffixing the main tree (`<repo>`, `<repo>-dev1`, `<repo>-dev2`), so the main
+tree's name appears inside every sibling's. Under a plain substring rule, typing
+the exact name of the main tree matches all of them and resolves to nothing,
+making the most common target the one tree you cannot name without an absolute
+path. Exact-beats-partial is how tab-completion already behaves.
+
+`--issue N` is the fallback when no hint resolves it: it finds the worktree on
+branch `issue-N-*`, so resumed work needs no argument at all. When no tree is on
+that branch — new work, before the branch exists — it reports the current
+worktree rather than failing, the same answer as no arguments at all. Detection
+that finds nothing is not an error; only a hint the user typed can be wrong.
+
+Ambiguity is the interesting case: a hint matching several trees, or none, exits
 non-zero with the candidates and their branches on stderr and **nothing on
-stdout**, so a `$(...)` capture cannot silently become a guess. With no argument
-and nothing to detect it prints the current worktree, leaving single-worktree
-projects exactly as they were.
+stdout**, so a `$(...)` capture cannot silently become a guess. Single-worktree
+projects never notice any of this.
 
 **`--repo` is the convention for every script that selects a git worktree**:
 `git-commit.sh`, `git-diff-base.sh`, `git-push-pr-merge.sh`, `git-verify.sh` and

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
 | `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents). Can print `ok N files changed` without committing — see [failure modes](docs/git-script-failure-modes.md) |
-| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). Repos without CI need `--no-ci-wait`. Creates the PR itself, so `gh pr create` hooks do not fire — see [failure modes](docs/git-script-failure-modes.md) |
+| `git-push-pr-merge.sh` | `git-push-pr-merge.sh [--repo DIR] [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). `--repo` targets a worktree instead of the current directory. Repos without CI need `--no-ci-wait`. Creates the PR itself, so `gh pr create` hooks do not fire — see [failure modes](docs/git-script-failure-modes.md) |
 
 `git-resolve-worktree.sh` exists because an agent's working directory resets
 between every Bash call, and so do exported variables. In a repository with
@@ -147,8 +147,14 @@ stdout**, so a `$(...)` capture cannot silently become a guess. With no argument
 and nothing to detect it prints the current worktree, leaving single-worktree
 projects exactly as they were.
 
-`git-find-base-branch` takes the same path, for the same reason: without it, it
-reads the start directory and reports the base branch of the wrong tree.
+`git-find-base-branch <dir>`, `git-commit.sh --repo`, `git-diff-base.sh --repo`
+and `git-push-pr-merge.sh --repo` all take that same path, for the same reason:
+without it they read the start directory and act on the wrong tree.
+`git-push-pr-merge.sh` is the one with real teeth — it pushes, opens a PR, and on
+merge runs `checkout` and `branch -D`, so a wrong target is destructive to a tree
+nobody is watching, so it validates the path itself and refuses before pushing;
+the others fail loudly through git. None of them fall back to the caller's
+directory.
 
 ### Project audits
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,32 @@ The `bin/` directory contains reusable shell scripts that skills call instead of
 
 | Script | Usage | Description |
 |--------|-------|-------------|
-| `git-find-base-branch` | `git-find-base-branch` | Detect the base branch of the current branch |
+| `git-find-base-branch` | `git-find-base-branch [repo-dir]` | Detect the base branch of the current branch, or of the worktree at `repo-dir` |
+| `git-resolve-worktree.sh` | `git-resolve-worktree.sh [--issue N] [hint]` | Resolve a worktree hint to one absolute path. Refuses to guess: zero or several matches exit non-zero and list the candidates with their branches |
 | `git-cleanup-merged-branch.sh` | `git-cleanup-merged-branch.sh [feature] [base]` | Checkout base, pull, delete merged feature branch |
 | `extract-issue-from-branch.sh` | `extract-issue-from-branch.sh` | Extract issue number from current branch name |
 | `git-commit.sh` | `git-commit.sh <message>` | Commit via temp file (avoids heredoc issues in sub-agents). Can print `ok N files changed` without committing — see [failure modes](docs/git-script-failure-modes.md) |
 | `git-push-pr-merge.sh` | `git-push-pr-merge.sh [options]` | Push, create PR, gate on CI checks (fail closed), merge, return to base (for `/implement-epic`). Repos without CI need `--no-ci-wait`. Creates the PR itself, so `gh pr create` hooks do not fire — see [failure modes](docs/git-script-failure-modes.md) |
+
+`git-resolve-worktree.sh` exists because an agent's working directory resets
+between every Bash call, and so do exported variables. In a repository with
+linked worktrees nothing carries "work in that tree" from one command to the
+next, so a bare `git` or a repo-relative path quietly acts on whichever directory
+the session started in. The failure is silent: a commit can land on another
+session's branch, carrying that session's staged files, and exit 0.
+
+The script turns a short hint into the one absolute path that every following
+command must carry (`git -C <path>`, `git-commit.sh --repo <path>`, absolute
+Read/Edit paths). `--issue N` finds the worktree on branch `issue-N-*`, so resumed
+work needs no argument at all; otherwise a case-insensitive substring of the path
+is enough. Ambiguity is the interesting case: several matches, or none, exit
+non-zero with the candidates and their branches on stderr and **nothing on
+stdout**, so a `$(...)` capture cannot silently become a guess. With no argument
+and nothing to detect it prints the current worktree, leaving single-worktree
+projects exactly as they were.
+
+`git-find-base-branch` takes the same path, for the same reason: without it, it
+reads the start directory and reports the base branch of the wrong tree.
 
 ### Project audits
 
@@ -198,7 +219,8 @@ claude-code-toolkit/
 ├── bin/                       ← helper scripts (batch operations, git utilities)
 │   ├── batch-issue-view.sh    ← fetch multiple issues as JSON array
 │   ├── batch-issue-status.sh  ← fetch issue status as JSON array
-│   ├── git-find-base-branch   ← detect base branch of current branch
+│   ├── git-find-base-branch   ← detect base branch (of a given worktree)
+│   ├── git-resolve-worktree.sh ← resolve a worktree hint to one absolute path
 │   ├── git-cleanup-merged-branch.sh ← cleanup after PR merge
 │   ├── git-commit.sh               ← commit via temp file (sub-agent safe)
 │   ├── git-push-pr-merge.sh        ← push, PR, merge, return to base

--- a/bin/git-find-base-branch
+++ b/bin/git-find-base-branch
@@ -15,6 +15,20 @@
 #      current branch (original heuristic) — covers repos without a
 #      develop/master/main branch.
 #   3. Last resort: first existing develop/master/main, even if not an ancestor.
+#
+# Usage:
+#   git-find-base-branch [repo-dir]
+#
+# Without an argument this reports on the current directory. With one it reports
+# on THAT worktree — necessary because an agent's working directory resets
+# between commands, so a caller working in a linked worktree would otherwise get
+# the base branch of whichever tree the session started in. Resolve the path with
+# git-resolve-worktree.sh rather than typing it out.
+
+REPO_DIR="${1:-}"
+if [ -n "$REPO_DIR" ]; then
+    cd "$REPO_DIR" || { echo "Error: cannot cd into repo '$REPO_DIR'." >&2; exit 1; }
+fi
 
 current=$(git branch --show-current)
 

--- a/bin/git-find-base-branch
+++ b/bin/git-find-base-branch
@@ -17,15 +17,47 @@
 #   3. Last resort: first existing develop/master/main, even if not an ancestor.
 #
 # Usage:
-#   git-find-base-branch [repo-dir]
+#   git-find-base-branch [repo-dir | --repo <dir>]
 #
 # Without an argument this reports on the current directory. With one it reports
 # on THAT worktree — necessary because an agent's working directory resets
 # between commands, so a caller working in a linked worktree would otherwise get
 # the base branch of whichever tree the session started in. Resolve the path with
 # git-resolve-worktree.sh rather than typing it out.
+#
+# --repo is the same argument, named, matching the other worktree-targeting
+# scripts (git-commit.sh, git-diff-base.sh, git-push-pr-merge.sh, git-verify.sh).
+# Naming the same tree twice is fine; naming two different ones is an error
+# rather than a silent pick.
 
-REPO_DIR="${1:-}"
+REPO_DIR=""
+
+set_repo() {
+    if [ -n "$REPO_DIR" ] && [ "$REPO_DIR" != "$1" ]; then
+        echo "Error: two different targets given ($REPO_DIR and $1)." >&2
+        exit 1
+    fi
+    REPO_DIR="$1"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)
+            [ $# -ge 2 ] || { echo "Error: --repo needs a directory." >&2; exit 1; }
+            set_repo "$2"
+            shift 2
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            set_repo "$1"
+            shift
+            ;;
+    esac
+done
+
 if [ -n "$REPO_DIR" ]; then
     cd "$REPO_DIR" || { echo "Error: cannot cd into repo '$REPO_DIR'." >&2; exit 1; }
 fi

--- a/bin/git-push-pr-merge.sh
+++ b/bin/git-push-pr-merge.sh
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   git-push-pr-merge.sh --base <base-branch> --title "PR title" --body-file /tmp/pr-body.md
+#   git-push-pr-merge.sh --repo <worktree> --base ... --title ... --body-file ...
 #
 # What it does:
 #   1. Push current branch to origin (with -u)
@@ -29,7 +30,19 @@
 #   printed, and the script exits non-zero so callers can react. Re-running
 #   with the same arguments reuses the open PR and re-runs the gate.
 #
+# Worktree targeting:
+#   Without --repo this acts on the current directory. That is the right default
+#   for a human in a shell, but wrong for an agent: an agent's working directory
+#   resets between every command, so the current directory is whichever tree the
+#   session started in, not necessarily the one holding the work. This script
+#   pushes a branch, opens a PR, and on merge runs `checkout` and `branch -D` —
+#   aimed at the wrong worktree that is destructive to a tree nobody is watching.
+#   Pass --repo (resolve it with git-resolve-worktree.sh) to say which tree.
+#
 # Options:
+#   --repo <dir>               Run against the worktree at <dir> instead of the
+#                              current directory. A path that is not a worktree
+#                              is an error, never a fallback to the caller's tree
 #   --base <branch>            Target branch for the PR (required)
 #   --title <title>            PR title (required)
 #   --body-file <path>         File containing PR body (required)
@@ -44,6 +57,7 @@ set -euo pipefail
 BASE=""
 TITLE=""
 BODY_FILE=""
+REPO_DIR=""
 DO_MERGE=1
 CI_WAIT=1
 CI_TIMEOUT=900
@@ -52,6 +66,10 @@ CI_GRACE=120
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --repo)
+            REPO_DIR="$2"
+            shift 2
+            ;;
         --base)
             BASE="$2"
             shift 2
@@ -107,6 +125,28 @@ fi
 if [[ ! -f "$BODY_FILE" ]]; then
     echo "Error: Body file not found: $BODY_FILE" >&2
     exit 1
+fi
+
+# Switch into the target worktree before any git/gh call. One `cd` covers every
+# call site, including `gh`, which derives its repository from the working
+# directory the same way git does.
+#
+# Resolve the body file to an absolute path FIRST: a relative --body-file is
+# relative to where the caller stood, and moving afterwards would break it.
+if [[ -n "$REPO_DIR" ]]; then
+    BODY_FILE=$(cd "$(dirname "$BODY_FILE")" && pwd)/$(basename "$BODY_FILE")
+
+    # A path that is not a worktree is an error, never a silent fallback to the
+    # caller's tree — that fallback is the exact bug this flag exists to prevent.
+    if [[ ! -d "$REPO_DIR" ]]; then
+        echo "Error: --repo directory not found: $REPO_DIR" >&2
+        exit 1
+    fi
+    if ! git -C "$REPO_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+        echo "Error: --repo is not inside a git worktree: $REPO_DIR" >&2
+        exit 1
+    fi
+    cd "$REPO_DIR" || { echo "Error: cannot cd into repo '$REPO_DIR'" >&2; exit 1; }
 fi
 
 # Both deadlines advance by CI_POLL_INTERVAL, so 0 (or a non-number) would spin

--- a/bin/git-resolve-worktree.sh
+++ b/bin/git-resolve-worktree.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# git-resolve-worktree.sh — Resolve a worktree hint to one absolute path.
+#
+# Why this exists
+# ---------------
+# An agent's working directory resets between every Bash call, so "work in that
+# other worktree" cannot be held in shell state. Every command has to carry the
+# target path explicitly. This script turns a short, human-sized hint into the
+# one absolute path those commands need, and refuses to guess when the hint is
+# ambiguous — a wrong worktree fails silently, which is the failure mode worth
+# spending an exit code on.
+#
+# Usage:
+#   git-resolve-worktree.sh                 # the worktree the caller is in
+#   git-resolve-worktree.sh --issue 42      # the worktree on branch issue-42-*
+#   git-resolve-worktree.sh dev1            # substring of a worktree path
+#   git-resolve-worktree.sh /abs/path       # an absolute path, validated
+#
+# Options:
+#   --issue N   Prefer the worktree whose branch is `issue-N-<slug>`. Combined
+#               with a hint, the hint decides and --issue is ignored.
+#
+# Output:
+#   success  one absolute worktree root on stdout, exit 0
+#   failure  nothing on stdout, diagnosis and candidates on stderr, exit 1
+#
+# Exit codes:
+#   0 = resolved   1 = unresolvable (no match, ambiguous, not a worktree)
+#   2 = usage error
+
+set -uo pipefail
+
+ISSUE=""
+HINT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --issue)
+            [[ $# -ge 2 ]] || { echo "usage: git-resolve-worktree.sh [--issue N] [hint]" >&2; exit 2; }
+            ISSUE="$2"
+            shift 2
+            ;;
+        --issue=*)
+            ISSUE="${1#--issue=}"
+            shift
+            ;;
+        -h|--help)
+            echo "usage: git-resolve-worktree.sh [--issue N] [hint]" >&2
+            exit 2
+            ;;
+        -*)
+            echo "usage: git-resolve-worktree.sh [--issue N] [hint]" >&2
+            exit 2
+            ;;
+        *)
+            [[ -n "$HINT" ]] && { echo "usage: git-resolve-worktree.sh [--issue N] [hint]" >&2; exit 2; }
+            HINT="$1"
+            shift
+            ;;
+    esac
+done
+
+# Everything is judged against the repository the caller is standing in. Without
+# one there is no worktree list to search and no sane default to fall back to.
+CURRENT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$CURRENT_ROOT" ]]; then
+    echo "git-resolve-worktree.sh: not inside a git repository" >&2
+    exit 1
+fi
+
+echo "$CURRENT_ROOT"

--- a/bin/git-resolve-worktree.sh
+++ b/bin/git-resolve-worktree.sh
@@ -147,12 +147,32 @@ if [[ -n "$HINT" ]]; then
         exit 0
     fi
 
-    # 1b. A substring of a worktree path, case-insensitively. Short enough to
-    #     type, and unique matching is what keeps it honest.
+    # 1b. An exact name wins outright. Worktree siblings are conventionally named
+    #     by suffixing the main tree (`<repo>`, `<repo>-dev1`, `<repo>-dev2`), so
+    #     the main tree's own name is a substring of every sibling. Under a plain
+    #     substring rule, typing the exact name of the main tree matches all of
+    #     them and resolves to nothing — making the most common target the one
+    #     tree you cannot name without an absolute path. Exact-beats-partial is
+    #     how tab-completion and package managers already behave.
     MATCHES=$(awk -F'\t' -v hint="$HINT" '
         BEGIN { hint = tolower(hint) }
-        index(tolower($1), hint) > 0
+        {
+            path = tolower($1)
+            base = path
+            sub(/^.*\//, "", base)
+            if (base == hint || path == hint) print
+        }
     ' <<< "$WORKTREES")
+
+    # 1c. Otherwise a substring, case-insensitively. Short enough to type, and
+    #     unique matching is what keeps it honest.
+    if [[ -z "$MATCHES" ]]; then
+        MATCHES=$(awk -F'\t' -v hint="$HINT" '
+            BEGIN { hint = tolower(hint) }
+            index(tolower($1), hint) > 0
+        ' <<< "$WORKTREES")
+    fi
+
     select_one "$MATCHES" "hint '$HINT'" || exit 1
     exit 0
 fi
@@ -162,8 +182,21 @@ fi
 #    is load-bearing: without it `--issue 7` also matches `issue-77-...`.
 if [[ -n "$ISSUE" ]]; then
     MATCHES=$(awk -F'\t' -v prefix="issue-$ISSUE-" 'index($2, prefix) == 1' <<< "$WORKTREES")
-    select_one "$MATCHES" "issue $ISSUE" || exit 1
-    exit 0
+
+    # No worktree on that branch is not an error. --issue is a detection attempt
+    # the CALLER makes on every run, not something the user typed: on new work
+    # the branch does not exist yet, which is the normal case, not a mistake.
+    # Falling through to the current worktree gives the same answer as no
+    # argument at all. Failing here would instead hand back no path, and whatever
+    # picks up the pieces would be guessing — the exact failure this script
+    # exists to prevent.
+    #
+    # Several matches IS an error: the branch convention is supposed to be
+    # unique, so two trees on `issue-N-*` is a genuine ambiguity to report.
+    if [[ -n "$MATCHES" ]]; then
+        select_one "$MATCHES" "issue $ISSUE" || exit 1
+        exit 0
+    fi
 fi
 
 # 3. No hint and no issue: the caller's own tree. Unchanged behaviour for the

--- a/bin/git-resolve-worktree.sh
+++ b/bin/git-resolve-worktree.sh
@@ -68,4 +68,72 @@ if [[ -z "$CURRENT_ROOT" ]]; then
     exit 1
 fi
 
+# Collect the repository's worktrees as `<path>\t<branch>` lines. --porcelain is
+# the stable machine format; a detached worktree gets an empty branch field
+# rather than being dropped, so it can still be matched by path and can still be
+# listed as a candidate.
+WORKTREES=$(
+    git worktree list --porcelain 2>/dev/null |
+    awk '
+        /^worktree /        { if (path != "") print path "\t" branch; path = substr($0, 10); branch = "" }
+        /^branch refs\/heads\// { branch = substr($0, 19) }
+        END                 { if (path != "") print path "\t" branch }
+    '
+)
+
+field() { # line index
+    printf '%s' "$1" | cut -f"$2"
+}
+
+# Report every worktree with its branch, so a failed resolve tells the caller
+# what they could have meant instead of just that they were wrong.
+list_candidates() { # lines...
+    local line path branch
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        path=$(field "$line" 1)
+        branch=$(field "$line" 2)
+        printf '  %s  [%s]\n' "$path" "${branch:-detached}" >&2
+    done <<< "$1"
+}
+
+# Narrow to at most one worktree, or explain why that was not possible. Nothing
+# is ever printed to stdout on failure: callers capture stdout in `$(...)`, so a
+# guess there would be indistinguishable from a real answer.
+select_one() { # matches description
+    local matches="$1" description="$2" count
+    count=$(grep -c . <<< "$matches")
+    [[ -z "$matches" ]] && count=0
+
+    if [[ "$count" -eq 1 ]]; then
+        field "$matches" 1
+        return 0
+    fi
+
+    if [[ "$count" -eq 0 ]]; then
+        echo "git-resolve-worktree.sh: $description matches no worktree of this repository." >&2
+    else
+        echo "git-resolve-worktree.sh: $description matches $count worktrees:" >&2
+        list_candidates "$matches"
+        echo "Be more specific — pass a longer hint or the absolute path." >&2
+    fi
+
+    if [[ "$count" -eq 0 ]]; then
+        echo "Known worktrees:" >&2
+        list_candidates "$WORKTREES"
+    fi
+    return 1
+}
+
+# 1. --issue: the branch convention `issue-<nr>-<slug>` makes the worktree
+#    derivable on resumed work, so the caller types nothing. The trailing dash
+#    is load-bearing: without it `--issue 7` also matches `issue-77-...`.
+if [[ -n "$ISSUE" ]]; then
+    MATCHES=$(awk -F'\t' -v prefix="issue-$ISSUE-" 'index($2, prefix) == 1' <<< "$WORKTREES")
+    select_one "$MATCHES" "issue $ISSUE" || exit 1
+    exit 0
+fi
+
+# 2. No hint and no issue: the caller's own tree. Unchanged behaviour for the
+#    single-worktree case, which is most repositories most of the time.
 echo "$CURRENT_ROOT"

--- a/bin/git-resolve-worktree.sh
+++ b/bin/git-resolve-worktree.sh
@@ -125,7 +125,39 @@ select_one() { # matches description
     return 1
 }
 
-# 1. --issue: the branch convention `issue-<nr>-<slug>` makes the worktree
+# 1. An explicit hint decides, because the caller said it out loud. Two forms,
+#    tried in order of how specific they are.
+if [[ -n "$HINT" ]]; then
+    # Expand a leading ~ so a shell-quoted path still resolves.
+    case "$HINT" in "~"/*) HINT="$HOME/${HINT#\~/}" ;; esac
+
+    # 1a. A path: validated against this repository's worktree list, never
+    #     trusted on sight. A typo that happens to be a real directory
+    #     elsewhere, or a worktree of another project, must fail loudly.
+    if [[ "$HINT" == /* || "$HINT" == ./* || "$HINT" == ../* ]]; then
+        HINT_ROOT=$(git -C "$HINT" rev-parse --show-toplevel 2>/dev/null || true)
+        if [[ -z "$HINT_ROOT" ]]; then
+            echo "git-resolve-worktree.sh: '$HINT' is not inside a git worktree." >&2
+            echo "Known worktrees:" >&2
+            list_candidates "$WORKTREES"
+            exit 1
+        fi
+        MATCHES=$(awk -F'\t' -v root="$HINT_ROOT" '$1 == root' <<< "$WORKTREES")
+        select_one "$MATCHES" "path '$HINT_ROOT'" || exit 1
+        exit 0
+    fi
+
+    # 1b. A substring of a worktree path, case-insensitively. Short enough to
+    #     type, and unique matching is what keeps it honest.
+    MATCHES=$(awk -F'\t' -v hint="$HINT" '
+        BEGIN { hint = tolower(hint) }
+        index(tolower($1), hint) > 0
+    ' <<< "$WORKTREES")
+    select_one "$MATCHES" "hint '$HINT'" || exit 1
+    exit 0
+fi
+
+# 2. --issue: the branch convention `issue-<nr>-<slug>` makes the worktree
 #    derivable on resumed work, so the caller types nothing. The trailing dash
 #    is load-bearing: without it `--issue 7` also matches `issue-77-...`.
 if [[ -n "$ISSUE" ]]; then
@@ -134,6 +166,6 @@ if [[ -n "$ISSUE" ]]; then
     exit 0
 fi
 
-# 2. No hint and no issue: the caller's own tree. Unchanged behaviour for the
+# 3. No hint and no issue: the caller's own tree. Unchanged behaviour for the
 #    single-worktree case, which is most repositories most of the time.
 echo "$CURRENT_ROOT"

--- a/bin/git-verify.sh
+++ b/bin/git-verify.sh
@@ -2,30 +2,56 @@
 # Read-only git status snapshot in one call — avoids a permission prompt per
 # individual command, which is the dominant friction during long epic runs.
 #
-# Usage: git-verify.sh [repo-dir] [--base <branch>] [--alembic]
+# Usage: git-verify.sh [repo-dir | --repo <dir>] [--base <branch>] [--alembic]
 #   repo-dir   defaults to the current directory
+#   --repo     same thing, named. Preferred when an agent calls this: a working
+#              directory resets between commands, so "." is whichever tree the
+#              session started in, not necessarily the one being worked on.
+#              Naming the target makes a wrong one visible in the command itself
 #   --base     also show commits on HEAD not in <branch>, and vice versa
 #   --alembic  also show alembic heads (fails loudly if more than one)
 #
+# Naming the same tree twice is fine; naming two different ones is an error
+# rather than a silent pick, because the loser is a tree the caller believed
+# they were looking at.
+#
 # Examples:
 #   git-verify.sh
+#   git-verify.sh --repo ~/Projects/Acme --base develop --alembic
 #   git-verify.sh ~/Projects/Acme --base develop --alembic
 #
 # Read-only by design: it never writes, fetches, checks out or stashes.
 set -euo pipefail
 
-repo="."
+repo=""
 base=""
 want_alembic=0
 
+# Track how the target was given so a second, conflicting one can be rejected.
+# Previously any unrecognised argument fell into the catch-all and overwrote
+# `repo`, so a typo (or a flag this script does not know) silently became the
+# target directory instead of an error.
+set_repo() { # path source
+  if [[ -n "$repo" && "$repo" != "$1" ]]; then
+    echo "git-verify: two different targets given ($repo and $1)" >&2
+    exit 1
+  fi
+  repo="$1"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo)    [[ $# -ge 2 ]] || { echo "git-verify: --repo needs a directory" >&2; exit 1; }
+               set_repo "$2"; shift 2 ;;
     --base)    base="${2:-}"; shift 2 ;;
     --alembic) want_alembic=1; shift ;;
-    -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
-    *)         repo="$1"; shift ;;
+    -h|--help) sed -n '2,23p' "$0"; exit 0 ;;
+    -*)        echo "git-verify: unknown option: $1" >&2; exit 1 ;;
+    *)         set_repo "$1"; shift ;;
   esac
 done
+
+repo="${repo:-.}"
 
 [[ -d "$repo" ]] || { echo "git-verify: no such directory: $repo" >&2; exit 1; }
 git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || {

--- a/bin/test-git-find-base-branch.sh
+++ b/bin/test-git-find-base-branch.sh
@@ -114,6 +114,70 @@ else
     pass=$((pass + 1))
 fi
 
+# --repo is the named spelling of the same argument, matching the other
+# worktree-targeting scripts (git-commit.sh, git-diff-base.sh, …). An agent
+# reading a command should see which tree it acts on without knowing each
+# script's argument order.
+actual=$(cd "$wt4" && "$TARGET" --repo "$repo4")
+if [ "$actual" = "develop" ]; then
+    echo "PASS: --repo targets the given worktree (got '$actual')"
+    pass=$((pass + 1))
+else
+    echo "FAIL: --repo targets the given worktree (expected 'develop', got '$actual')"
+    fail=$((fail + 1))
+fi
+
+actual=$(cd "$repo4" && "$TARGET" --repo "$wt4")
+if [ "$actual" = "master" ]; then
+    echo "PASS: --repo works in the other direction (got '$actual')"
+    pass=$((pass + 1))
+else
+    echo "FAIL: --repo works in the other direction (expected 'master', got '$actual')"
+    fail=$((fail + 1))
+fi
+
+if (cd "$repo4" && "$TARGET" --repo "${repo4}-nonexistent" >/dev/null 2>&1); then
+    echo "FAIL: nonexistent --repo exits non-zero"
+    fail=$((fail + 1))
+else
+    echo "PASS: nonexistent --repo exits non-zero"
+    pass=$((pass + 1))
+fi
+
+if (cd "$repo4" && "$TARGET" --repo >/dev/null 2>&1); then
+    echo "FAIL: --repo without a value exits non-zero"
+    fail=$((fail + 1))
+else
+    echo "PASS: --repo without a value exits non-zero"
+    pass=$((pass + 1))
+fi
+
+# Two different trees named at once is a conflict, not a pick: the loser is a
+# tree the caller believed they were asking about.
+if (cd "$repo4" && "$TARGET" "$wt4" --repo "$repo4" >/dev/null 2>&1); then
+    echo "FAIL: conflicting targets exit non-zero"
+    fail=$((fail + 1))
+else
+    echo "PASS: conflicting targets exit non-zero"
+    pass=$((pass + 1))
+fi
+
+# An unknown option must be REJECTED as an option, not swallowed as the target
+# directory. Asserting only on the exit code is not enough: a fall-through makes
+# `cd --nope` fail too, so the case would pass while the bug is present. The
+# message is what distinguishes the two.
+err=$(cd "$repo4" && "$TARGET" --nope 2>&1 >/dev/null) || true
+case "$err" in
+    *"unknown option"*)
+        echo "PASS: unknown option rejected as an option"
+        pass=$((pass + 1))
+        ;;
+    *)
+        echo "FAIL: unknown option rejected as an option (got '$err')"
+        fail=$((fail + 1))
+        ;;
+esac
+
 git -C "$repo4" worktree remove --force "$wt4" >/dev/null 2>&1
 rm -rf "$repo4" "$wt4"
 

--- a/bin/test-git-find-base-branch.sh
+++ b/bin/test-git-find-base-branch.sh
@@ -70,6 +70,53 @@ git -C "$repo3" commit -q --allow-empty -m "feature work"
 run_case "repo without develop" "master" "$repo3"
 rm -rf "$repo3"
 
+# Scenario 4: an explicit repo argument reports THAT tree's base branch.
+#
+# Run from a linked worktree whose own answer differs from the target's, so the
+# case fails if the argument is ignored and the caller's directory wins. That is
+# the real bug: an agent working in a linked worktree would otherwise get the
+# base branch of whichever tree the session happened to start in.
+repo4=$(make_repo)
+git -C "$repo4" checkout -q -b master
+git -C "$repo4" commit -q --allow-empty -m "master root"
+git -C "$repo4" checkout -q -b develop
+git -C "$repo4" commit -q --allow-empty -m "develop ahead"
+wt4="${repo4}-dev1"
+git -C "$repo4" worktree add -q -b issue-42-invoice-rounding "$wt4" master >/dev/null 2>&1
+
+# From the linked tree (base master), ask about the main tree (on develop).
+actual=$(cd "$wt4" && "$TARGET" "$repo4")
+if [ "$actual" = "develop" ]; then
+    echo "PASS: repo argument targets the given worktree (got '$actual')"
+    pass=$((pass + 1))
+else
+    echo "FAIL: repo argument targets the given worktree (expected 'develop', got '$actual')"
+    fail=$((fail + 1))
+fi
+
+# And the reverse, so the case cannot pass by always reporting develop.
+actual=$(cd "$repo4" && "$TARGET" "$wt4")
+if [ "$actual" = "master" ]; then
+    echo "PASS: repo argument works in the other direction (got '$actual')"
+    pass=$((pass + 1))
+else
+    echo "FAIL: repo argument works in the other direction (expected 'master', got '$actual')"
+    fail=$((fail + 1))
+fi
+
+# A bad path must fail loudly. Falling back to the caller's directory here would
+# turn a typo into a confidently wrong answer.
+if (cd "$repo4" && "$TARGET" "${repo4}-nonexistent" >/dev/null 2>&1); then
+    echo "FAIL: nonexistent repo argument exits non-zero"
+    fail=$((fail + 1))
+else
+    echo "PASS: nonexistent repo argument exits non-zero"
+    pass=$((pass + 1))
+fi
+
+git -C "$repo4" worktree remove --force "$wt4" >/dev/null 2>&1
+rm -rf "$repo4" "$wt4"
+
 echo ""
 echo "Results: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/bin/test-git-find-base-branch.sh
+++ b/bin/test-git-find-base-branch.sh
@@ -14,6 +14,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TARGET="$SCRIPT_DIR/git-find-base-branch"
 
+# Every scenario repo goes under one temp root, removed on EXIT. The per-scenario
+# `rm -rf` at the end of each block only runs when that block completes, so under
+# `set -e` a failing assertion used to leave the repo (and its linked worktree)
+# behind — one orphaned pair per red run, which is exactly what a TDD cycle
+# produces. The trap fires on the failure path too.
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
 pass=0
 fail=0
 
@@ -34,7 +42,7 @@ run_case() {
 
 make_repo() {
     local dir
-    dir=$(mktemp -d)
+    dir=$(mktemp -d -p "$TEST_ROOT")
     git -C "$dir" init -q
     git -C "$dir" config user.email "test@example.com"
     git -C "$dir" config user.name "Test"

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -26,12 +26,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TARGET="$SCRIPT_DIR/git-push-pr-merge.sh"
 
+# One temp root for every scenario repo, removed on EXIT. The per-scenario
+# `rm -rf` only runs when that scenario completes, so under `set -e` a failing
+# assertion would leave the repo (and scenario 14's linked worktrees) behind.
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
 pass=0
 fail=0
 
 make_repo() {
     local dir
-    dir=$(mktemp -d)
+    dir=$(mktemp -d -p "$TEST_ROOT")
     git -C "$dir" init -q
     git -C "$dir" config user.email "test@example.com"
     git -C "$dir" config user.name "Test"

--- a/bin/test-git-push-pr-merge.sh
+++ b/bin/test-git-push-pr-merge.sh
@@ -480,6 +480,89 @@ assert_exit "zero poll: exit code" "1" "$(cat "$repo13/last-exit.txt")"
 assert_file_absent "zero poll: no merge" "$repo13/merged"
 rm -rf "$repo13"
 
+# --- Scenario 14: --repo acts on the target worktree, not the caller's ---
+# The whole point of the flag. An agent's working directory resets between Bash
+# calls, so without --repo this script pushes whatever branch the session's start
+# directory happens to be on — and after a merge it also runs `checkout` and
+# `branch -D` there, which is destructive in a tree nobody is looking at.
+#
+# Every case below runs from a DIFFERENT worktree than the target, and the two
+# are on different branches. If --repo were ignored, the caller's branch name
+# would surface instead and each assertion fails.
+repo14=$(make_repo)
+make_fake_gh "$repo14"
+echo "Test PR body" > "$repo14/body.md"
+
+# A linked worktree of the same repo, on its own branch. This is the realistic
+# shape: two trees, one repository, two sessions.
+wt14="${repo14}-dev1"
+git -C "$repo14" worktree add -q -b issue-99-other-work "$wt14" main >/dev/null 2>&1
+
+# Run FROM the linked tree (on issue-99-other-work), TARGETING the main tree
+# (on issue-1-feature).
+set +e
+out14=$(cd "$wt14" && PATH="$repo14/bin:$PATH" "$TARGET" --repo "$repo14" \
+    --base main --title "Test PR" --body-file "$repo14/body.md" --no-merge 2>&1)
+exit14=$?
+set -e
+
+assert_contains "--repo: pushes the target's branch" "Pushing issue-1-feature" "$out14"
+assert_exit "--repo: exit code" "0" "$exit14"
+# The caller's own branch must not appear anywhere — that would mean the script
+# read the working directory after all.
+if echo "$out14" | grep -qF "issue-99-other-work"; then
+    echo "FAIL: --repo: caller's branch leaked into the run"
+    echo "--- output ---"; echo "$out14"; echo "--------------"
+    fail=$((fail + 1))
+else
+    echo "PASS: --repo: caller's branch never used"
+    pass=$((pass + 1))
+fi
+
+# The same-branch-as-base guard must also judge the TARGET tree, not the caller.
+# Targeting a tree that sits on `main` has to be refused even though the caller
+# is on a feature branch and looks fine.
+main14="${repo14}-mainwt"
+git -C "$repo14" worktree add -q --detach "$main14" main >/dev/null 2>&1
+git -C "$main14" checkout -q main 2>/dev/null || git -C "$main14" switch -q -c main-copy main
+set +e
+out14b=$(cd "$wt14" && PATH="$repo14/bin:$PATH" "$TARGET" --repo "$main14" \
+    --base "$(git -C "$main14" branch --show-current)" --title "Test PR" \
+    --body-file "$repo14/body.md" --no-merge 2>&1)
+exit14b=$?
+set -e
+assert_contains "--repo: base-equals-current judged on target" "same as base" "$out14b"
+assert_exit "--repo: base-equals-current exit code" "1" "$exit14b"
+
+# A bad path fails loudly. Falling back to the caller's directory here is exactly
+# the silent-wrong-tree bug the flag exists to prevent.
+set +e
+out14c=$(cd "$wt14" && PATH="$repo14/bin:$PATH" "$TARGET" --repo "${repo14}-nonexistent" \
+    --base main --title "Test PR" --body-file "$repo14/body.md" --no-merge 2>&1)
+exit14c=$?
+set -e
+assert_exit "--repo: nonexistent path exits non-zero" "1" "$exit14c"
+if echo "$out14c" | grep -qF "Pushing"; then
+    echo "FAIL: --repo: pushed despite a bad --repo path"
+    fail=$((fail + 1))
+else
+    echo "PASS: --repo: nothing pushed on a bad path"
+    pass=$((pass + 1))
+fi
+
+# Without --repo the behaviour is unchanged: the caller's own tree is used.
+set +e
+out14d=$(cd "$wt14" && PATH="$repo14/bin:$PATH" "$TARGET" \
+    --base main --title "Test PR" --body-file "$repo14/body.md" --no-merge 2>&1)
+exit14d=$?
+set -e
+assert_contains "no --repo: uses caller's tree" "Pushing issue-99-other-work" "$out14d"
+assert_exit "no --repo: exit code" "0" "$exit14d"
+
+git -C "$repo14" worktree remove --force "$wt14" >/dev/null 2>&1 || true
+git -C "$repo14" worktree remove --force "$main14" >/dev/null 2>&1 || true
+rm -rf "$repo14" "$wt14" "$main14"
+
 echo ""
 echo "Results: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/bin/tests/test-git-resolve-worktree.sh
+++ b/bin/tests/test-git-resolve-worktree.sh
@@ -112,6 +112,37 @@ check "nonexistent absolute path exits non-zero" "1" \
 # An explicit hint decides; --issue is only the fallback for when none was given.
 check "hint wins over --issue" "$DEV1" "$(run "$MAIN" --issue 108 dev1)"
 
+echo "== 4. ambiguity is refused, never resolved by picking one =="
+# 'dev' matches both dev1 and dev2. Picking either would be a coin flip whose
+# loss is a commit in a tree the user never opened.
+check "ambiguous hint exits non-zero" "1" "$(run "$MAIN" dev >/dev/null 2>&1; echo $?)"
+check "ambiguous hint prints nothing on stdout" "" "$(run "$MAIN" dev 2>/dev/null)"
+AMBIG=$(run "$MAIN" dev 2>&1 >/dev/null)
+check "names both candidates" "2" "$(grep -c 'billing-api-dev[12]' <<< "$AMBIG")"
+# Path alone does not distinguish the two; the branch is what tells the user
+# which tree holds the work they mean.
+check "shows the first branch" "yes" \
+    "$(case "$AMBIG" in *issue-77-invoice-rounding*) echo yes ;; *) echo no ;; esac)"
+check "shows the second branch" "yes" \
+    "$(case "$AMBIG" in *issue-108-vat-export*) echo yes ;; *) echo no ;; esac)"
+# A substring matching every worktree, including the main tree, is the other
+# shape of the same mistake — 'billing-api' looks specific but matches all three.
+check "repo-wide substring is ambiguous too" "1" \
+    "$(run "$MAIN" billing-api >/dev/null 2>&1; echo $?)"
+# A failed resolve must leave nothing on stdout for `$(...)` to capture, or the
+# caller silently proceeds with an empty path that `git -C ''` reads as cwd.
+check "no match prints nothing on stdout" "" "$(run "$MAIN" nope 2>/dev/null)"
+check "unknown issue prints nothing on stdout" "" "$(run "$MAIN" --issue 999 2>/dev/null)"
+# The no-match message must still show where the caller could go instead.
+NOMATCH=$(run "$MAIN" nope 2>&1 >/dev/null)
+check "no match lists known worktrees" "3" "$(grep -c 'billing-api' <<< "$NOMATCH")"
+
+echo "== 5. argument validation =="
+check "two hints exit 2" "2" "$(run "$MAIN" dev1 dev2 >/dev/null 2>&1; echo $?)"
+check "unknown option exits 2" "2" "$(run "$MAIN" --nope >/dev/null 2>&1; echo $?)"
+check "usage goes to stderr" "yes" \
+    "$(case "$(run "$MAIN" --nope 2>&1 >/dev/null)" in *usage*) echo yes ;; *) echo no ;; esac)"
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/bin/tests/test-git-resolve-worktree.sh
+++ b/bin/tests/test-git-resolve-worktree.sh
@@ -93,6 +93,25 @@ check "unknown issue exits non-zero" "1" "$(run "$MAIN" --issue 999 >/dev/null 2
 check "--issue wins over the caller's tree" "$DEV2" "$(run "$DEV1" --issue 108)"
 check "--issue without a value exits 2" "2" "$(run "$MAIN" --issue >/dev/null 2>&1; echo $?)"
 
+echo "== 3. a hint is a case-insensitive substring of a worktree path =="
+check "unique substring" "$DEV1" "$(run "$MAIN" dev1)"
+check "uppercase hint" "$DEV2" "$(run "$MAIN" DEV2)"
+check "mixed case hint" "$DEV1" "$(run "$MAIN" Dev1)"
+check "hint exit 0" "0" "$(run "$MAIN" dev1 >/dev/null 2>&1; echo $?)"
+check "no such hint exits non-zero" "1" "$(run "$MAIN" nope >/dev/null 2>&1; echo $?)"
+# An absolute path is the escape hatch when no short hint is unique, but it is
+# validated rather than trusted: a typo must fail loudly, not point somewhere.
+check "absolute path passes through" "$DEV2" "$(run "$MAIN" "$DEV2")"
+check "trailing slash tolerated" "$DEV2" "$(run "$MAIN" "$DEV2/")"
+check "subdirectory of a worktree resolves to its root" "$DEV1" "$(run "$MAIN" "$DEV1/src/billing")"
+# A worktree of a DIFFERENT repository is a valid worktree, just not one of
+# ours. Accepting it would commit this session's work into an unrelated project.
+check "another repo's worktree is refused" "1" "$(run "$MAIN" "$OTHER" >/dev/null 2>&1; echo $?)"
+check "nonexistent absolute path exits non-zero" "1" \
+    "$(run "$MAIN" "$T/billing-api-dev9" >/dev/null 2>&1; echo $?)"
+# An explicit hint decides; --issue is only the fallback for when none was given.
+check "hint wins over --issue" "$DEV1" "$(run "$MAIN" --issue 108 dev1)"
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/bin/tests/test-git-resolve-worktree.sh
+++ b/bin/tests/test-git-resolve-worktree.sh
@@ -79,6 +79,20 @@ check "from a subdirectory" "$DEV1" "$(run "$DEV1/src/billing")"
 # exact silent fallback this script exists to prevent.
 check "outside a repository exits non-zero" "1" "$(run "$T" >/dev/null 2>&1; echo $?)"
 
+echo "== 2. --issue picks the worktree whose branch is issue-<nr>-<slug> =="
+check "matches its own tree" "$DEV1" "$(run "$MAIN" --issue 77)"
+check "matches the other tree" "$DEV2" "$(run "$MAIN" --issue 108)"
+check "--issue=N spelling" "$DEV2" "$(run "$MAIN" --issue=108)"
+# The pattern must end at the dash. Without it `7` matches `issue-77-*` and the
+# work lands one tree over, which is precisely the silent failure this prevents.
+check "7 does not match issue-77" "1" "$(run "$MAIN" --issue 7 >/dev/null 2>&1; echo $?)"
+check "10 does not match issue-108" "1" "$(run "$MAIN" --issue 10 >/dev/null 2>&1; echo $?)"
+check "unknown issue exits non-zero" "1" "$(run "$MAIN" --issue 999 >/dev/null 2>&1; echo $?)"
+# Resolving from inside a linked tree must still obey --issue, otherwise an
+# agent already sitting in dev1 would silently keep working there.
+check "--issue wins over the caller's tree" "$DEV2" "$(run "$DEV1" --issue 108)"
+check "--issue without a value exits 2" "2" "$(run "$MAIN" --issue >/dev/null 2>&1; echo $?)"
+
 echo
 echo "PASS: $PASS  FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/bin/tests/test-git-resolve-worktree.sh
+++ b/bin/tests/test-git-resolve-worktree.sh
@@ -85,9 +85,11 @@ check "matches the other tree" "$DEV2" "$(run "$MAIN" --issue 108)"
 check "--issue=N spelling" "$DEV2" "$(run "$MAIN" --issue=108)"
 # The pattern must end at the dash. Without it `7` matches `issue-77-*` and the
 # work lands one tree over, which is precisely the silent failure this prevents.
-check "7 does not match issue-77" "1" "$(run "$MAIN" --issue 7 >/dev/null 2>&1; echo $?)"
-check "10 does not match issue-108" "1" "$(run "$MAIN" --issue 10 >/dev/null 2>&1; echo $?)"
-check "unknown issue exits non-zero" "1" "$(run "$MAIN" --issue 999 >/dev/null 2>&1; echo $?)"
+# An unmatched --issue falls back to the caller's tree (section 3c), so what
+# matters here is that it never resolves to the wrong SIBLING.
+check "7 does not match issue-77" "$MAIN" "$(run "$MAIN" --issue 7)"
+check "10 does not match issue-108" "$MAIN" "$(run "$MAIN" --issue 10)"
+check "7 from a linked tree stays there" "$DEV2" "$(run "$DEV2" --issue 7)"
 # Resolving from inside a linked tree must still obey --issue, otherwise an
 # agent already sitting in dev1 would silently keep working there.
 check "--issue wins over the caller's tree" "$DEV2" "$(run "$DEV1" --issue 108)"
@@ -112,6 +114,40 @@ check "nonexistent absolute path exits non-zero" "1" \
 # An explicit hint decides; --issue is only the fallback for when none was given.
 check "hint wins over --issue" "$DEV1" "$(run "$MAIN" --issue 108 dev1)"
 
+echo "== 3b. an exact name beats a substring of its own siblings =="
+# The main tree's name is a prefix of every sibling's ("billing-api" is inside
+# "billing-api-dev1"), so a plain substring search finds the parent AND all its
+# children. Typing the exact name of a worktree must therefore mean THAT tree,
+# not "these three are all candidates" — otherwise naming the main tree is
+# impossible without typing an absolute path, which is the thing hints exist to
+# avoid. This is how tab-completion and package managers already behave.
+check "exact basename wins over its children" "$MAIN" "$(run "$MAIN" billing-api)"
+check "exact basename exits 0" "0" "$(run "$MAIN" billing-api >/dev/null 2>&1; echo $?)"
+check "exact basename from another tree" "$MAIN" "$(run "$DEV1" billing-api)"
+check "exact match is case-insensitive too" "$MAIN" "$(run "$DEV1" BILLING-API)"
+# A child's exact name still resolves to the child — the rule is "exact wins",
+# not "the parent always wins".
+check "exact child name still wins" "$DEV1" "$(run "$MAIN" billing-api-dev1)"
+# A full path is exact too, and must not be defeated by a longer sibling path.
+check "exact full path wins" "$MAIN" "$(run "$DEV1" "$MAIN")"
+# Without an exact hit, ambiguity still stands (see section 4).
+check "partial hint stays ambiguous" "1" "$(run "$MAIN" billing- >/dev/null 2>&1; echo $?)"
+
+echo "== 3c. failed --issue detection falls back to the caller's tree =="
+# --issue is a DETECTION attempt the skill always makes, not something the user
+# typed. When no worktree is on that branch — new work, before the branch exists
+# — the honest answer is "the tree you are in", exactly as with no argument at
+# all. Failing here strands the caller with no path, and whatever picks up the
+# pieces is guessing, which is what this script exists to prevent.
+check "unmatched --issue yields the caller's tree" "$MAIN" "$(run "$MAIN" --issue 4242)"
+check "unmatched --issue exits 0" "0" "$(run "$MAIN" --issue 4242 >/dev/null 2>&1; echo $?)"
+check "unmatched --issue from a linked tree" "$DEV1" "$(run "$DEV1" --issue 4242)"
+# A hint the user typed is different: that is an explicit instruction, so a miss
+# stays an error rather than quietly becoming "never mind, stay here".
+check "unmatched hint is still an error" "1" "$(run "$MAIN" --issue 4242 nope >/dev/null 2>&1; echo $?)"
+# Detection must still win when it does match.
+check "matched --issue still wins" "$DEV1" "$(run "$MAIN" --issue 77)"
+
 echo "== 4. ambiguity is refused, never resolved by picking one =="
 # 'dev' matches both dev1 and dev2. Picking either would be a coin flip whose
 # loss is a commit in a tree the user never opened.
@@ -125,14 +161,16 @@ check "shows the first branch" "yes" \
     "$(case "$AMBIG" in *issue-77-invoice-rounding*) echo yes ;; *) echo no ;; esac)"
 check "shows the second branch" "yes" \
     "$(case "$AMBIG" in *issue-108-vat-export*) echo yes ;; *) echo no ;; esac)"
-# A substring matching every worktree, including the main tree, is the other
-# shape of the same mistake — 'billing-api' looks specific but matches all three.
+# A substring matching every worktree is the other shape of the same mistake.
+# 'billing-' looks specific but matches all three, and is nobody's exact name.
 check "repo-wide substring is ambiguous too" "1" \
-    "$(run "$MAIN" billing-api >/dev/null 2>&1; echo $?)"
+    "$(run "$MAIN" billing- >/dev/null 2>&1; echo $?)"
 # A failed resolve must leave nothing on stdout for `$(...)` to capture, or the
 # caller silently proceeds with an empty path that `git -C ''` reads as cwd.
 check "no match prints nothing on stdout" "" "$(run "$MAIN" nope 2>/dev/null)"
-check "unknown issue prints nothing on stdout" "" "$(run "$MAIN" --issue 999 2>/dev/null)"
+# An unmatched --issue is NOT a failure (section 3c), so it is deliberately not
+# asserted here. A hint the user typed still is.
+check "ambiguous hint prints nothing again" "" "$(run "$MAIN" billing- 2>/dev/null)"
 # The no-match message must still show where the caller could go instead.
 NOMATCH=$(run "$MAIN" nope 2>&1 >/dev/null)
 check "no match lists known worktrees" "3" "$(grep -c 'billing-api' <<< "$NOMATCH")"

--- a/bin/tests/test-git-resolve-worktree.sh
+++ b/bin/tests/test-git-resolve-worktree.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Tests for git-resolve-worktree.sh.
+#
+# Usage:
+#   bin/tests/test-git-resolve-worktree.sh
+#
+# Runs against a throwaway repository with REAL linked worktrees. The thing
+# under test is how the script reads `git worktree list` and narrows it down, so
+# stubbing git would test the stub. Every case below builds its own trees and
+# removes them on exit.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="${SCRIPT_UNDER_TEST:-$SCRIPT_DIR/../git-resolve-worktree.sh}"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "script not found: $SCRIPT" >&2
+    exit 1
+fi
+
+PASS=0; FAIL=0
+
+check() { # name expected actual
+    if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1))
+    else echo "  FAIL: $1 (expected '$2', got '$3')"; FAIL=$((FAIL+1)); fi
+}
+
+# --- a real repository with real linked worktrees ----------------------------
+# Layout mirrors how these are used in practice: a main tree on `main`, plus two
+# sibling trees named after the developer slot, each checked out on an issue
+# branch following the `issue-<nr>-<slug>` convention.
+#
+#   <T>/billing-api        main
+#   <T>/billing-api-dev1   issue-77-invoice-rounding
+#   <T>/billing-api-dev2   issue-108-vat-export
+#
+# Issue numbers 77 and 108 are deliberate: 7 is a prefix of 77, and 10 a prefix
+# of 108, so a resolver matching without the trailing dash picks the wrong tree.
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+MAIN="$T/billing-api"
+DEV1="$T/billing-api-dev1"
+DEV2="$T/billing-api-dev2"
+
+git init -q -b main "$MAIN"
+git -C "$MAIN" config user.email "dev@example.com"
+git -C "$MAIN" config user.name "Test Developer"
+git -C "$MAIN" commit -q --allow-empty -m "initial commit"
+
+git -C "$MAIN" worktree add -q -b issue-77-invoice-rounding "$DEV1" >/dev/null 2>&1
+git -C "$MAIN" worktree add -q -b issue-108-vat-export "$DEV2" >/dev/null 2>&1
+
+# An unrelated repository, to prove a path outside this repo is refused rather
+# than accepted just because it happens to be a valid git worktree somewhere.
+OTHER="$T/unrelated-project"
+git init -q -b main "$OTHER"
+git -C "$OTHER" config user.email "dev@example.com"
+git -C "$OTHER" config user.name "Test Developer"
+git -C "$OTHER" commit -q --allow-empty -m "initial commit"
+
+# Run from a given directory: the script's default is "where I am", so the
+# working directory is an input, not incidental setup.
+run() { # cwd [args...]
+    local cwd="$1"; shift
+    (cd "$cwd" && bash "$SCRIPT" "$@")
+}
+
+echo "== 1. no argument resolves to the worktree the caller is in =="
+check "from the main tree" "$MAIN" "$(run "$MAIN")"
+check "from a linked tree" "$DEV1" "$(run "$DEV1")"
+check "exit 0 without argument" "0" "$(run "$MAIN" >/dev/null 2>&1; echo $?)"
+# A subdirectory must resolve to the tree ROOT — the path is handed to
+# `git -C` and to absolute Read/Edit paths, so the root is the only useful answer.
+mkdir -p "$DEV1/src/billing"
+check "from a subdirectory" "$DEV1" "$(run "$DEV1/src/billing")"
+# Outside any repository there is nothing to resolve, and guessing would be the
+# exact silent fallback this script exists to prevent.
+check "outside a repository exits non-zero" "1" "$(run "$T" >/dev/null 2>&1; echo $?)"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/bin/tests/test-git-verify.sh
+++ b/bin/tests/test-git-verify.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Tests for git-verify.sh's repository targeting.
+#
+# Usage:
+#   bin/tests/test-git-verify.sh
+#
+# Scope: which tree the script reports on, not the formatting of every section.
+# That is the part an agent gets wrong — a working directory resets between Bash
+# calls, so a script reading "." silently reports on whichever tree the session
+# started in. Everything runs against throwaway repos with real linked worktrees.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="${SCRIPT_UNDER_TEST:-$SCRIPT_DIR/../git-verify.sh}"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "script not found: $SCRIPT" >&2
+    exit 1
+fi
+
+PASS=0; FAIL=0
+
+check() { # name expected actual
+    if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1))
+    else echo "  FAIL: $1 (expected '$2', got '$3')"; FAIL=$((FAIL+1)); fi
+}
+
+# Two worktrees of one repository, on different branches. Every case below runs
+# from one and targets the other, so a script that ignores its argument reports
+# the caller's branch and the assertion fails.
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+MAIN="$T/billing-api"
+DEV1="$T/billing-api-dev1"
+
+git init -q -b main "$MAIN"
+git -C "$MAIN" config user.email "dev@example.com"
+git -C "$MAIN" config user.name "Test Developer"
+git -C "$MAIN" commit -q --allow-empty -m "initial commit"
+git -C "$MAIN" worktree add -q -b issue-77-invoice-rounding "$DEV1" >/dev/null 2>&1
+
+run() { # cwd [args...]
+    local cwd="$1"; shift
+    (cd "$cwd" && bash "$SCRIPT" "$@" 2>&1)
+}
+
+# The reported branch is the cheapest unambiguous proof of which tree was read.
+branch_of() { grep -A1 '^=== branch ===$' <<< "$1" | tail -1; }
+
+echo "== 1. --repo targets the given worktree, not the caller's =="
+check "--repo from the other tree" "issue-77-invoice-rounding" \
+    "$(branch_of "$(run "$MAIN" --repo "$DEV1")")"
+# The reverse direction too, so the case cannot pass by always reporting one branch.
+check "--repo in the other direction" "main" \
+    "$(branch_of "$(run "$DEV1" --repo "$MAIN")")"
+check "--repo exits 0" "0" "$(run "$MAIN" --repo "$DEV1" >/dev/null 2>&1; echo $?)"
+
+echo "== 2. the positional path keeps working (no regression) =="
+check "positional from the other tree" "issue-77-invoice-rounding" \
+    "$(branch_of "$(run "$MAIN" "$DEV1")")"
+check "positional in the other direction" "main" \
+    "$(branch_of "$(run "$DEV1" "$MAIN")")"
+# Options after the positional path must still parse.
+check "positional with --base" "issue-77-invoice-rounding" \
+    "$(branch_of "$(run "$MAIN" "$DEV1" --base main)")"
+
+echo "== 3. no argument reports the caller's own tree =="
+check "bare run in main" "main" "$(branch_of "$(run "$MAIN")")"
+check "bare run in linked tree" "issue-77-invoice-rounding" "$(branch_of "$(run "$DEV1")")"
+
+echo "== 4. a bad target fails loudly, never falls back to the caller =="
+check "nonexistent --repo exits non-zero" "1" \
+    "$(run "$MAIN" --repo "$T/billing-api-dev9" >/dev/null 2>&1; echo $?)"
+check "non-repo --repo exits non-zero" "1" \
+    "$(run "$MAIN" --repo "$T" >/dev/null 2>&1; echo $?)"
+# Falling back would print the caller's branch and exit 0 — the silent wrong-tree
+# answer this flag exists to prevent.
+check "bad --repo prints no branch" "yes" \
+    "$(case "$(run "$MAIN" --repo "$T/billing-api-dev9")" in *"=== branch ==="*) echo no ;; *) echo yes ;; esac)"
+check "--repo without a value exits non-zero" "1" \
+    "$(run "$MAIN" --repo >/dev/null 2>&1; echo $?)"
+
+echo "== 5. conflicting targets are refused rather than silently resolved =="
+# Two paths meaning two different trees: picking either is a guess, and the loser
+# is a tree the caller believed they were looking at.
+check "--repo plus a different positional exits non-zero" "1" \
+    "$(run "$MAIN" "$MAIN" --repo "$DEV1" >/dev/null 2>&1; echo $?)"
+check "two positional paths exit non-zero" "1" \
+    "$(run "$MAIN" "$MAIN" "$DEV1" >/dev/null 2>&1; echo $?)"
+# The same tree named twice is not a conflict — nothing is ambiguous.
+check "--repo matching the positional is fine" "0" \
+    "$(run "$MAIN" "$DEV1" --repo "$DEV1" >/dev/null 2>&1; echo $?)"
+
+echo "== 6. an unknown option is an error, not a target directory =="
+# The original catch-all swallowed anything unrecognised into `repo`, so a typo
+# became a silent target instead of a complaint.
+check "unknown option exits non-zero" "1" \
+    "$(run "$MAIN" --nope >/dev/null 2>&1; echo $?)"
+check "unknown option names itself" "yes" \
+    "$(case "$(run "$MAIN" --nope)" in *"unknown option"*) echo yes ;; *) echo no ;; esac)"
+# A mistyped --repo must not degrade into "report on the caller's tree".
+check "mistyped --repo does not report a branch" "yes" \
+    "$(case "$(run "$MAIN" --rep "$DEV1")" in *"=== branch ==="*) echo no ;; *) echo yes ;; esac)"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -358,11 +358,10 @@ at the wrong one lands on another session's branch and exits 0.
 8. If tests pass:
    - Commit any remaining uncommitted work: `~/.claude/bin/git-commit.sh --repo <worktree> "concise descriptive message"`
    - Write PR body to /tmp/<project>-pr-body-<N>.md using the Write tool, then push + PR + merge in one command:
-     `~/.claude/bin/git-push-pr-merge.sh --base <feature_branch> --title "<title>" --body-file /tmp/<project>-pr-body-<N>.md`
-   - **This script has no `--repo` flag — it acts on the current directory.** If
-     `<worktree>` is not your start directory, do not run it: report the branch
-     you pushed in your response and let the orchestrator open the PR instead.
-     A blind run here pushes whatever branch the start directory is on.
+     `~/.claude/bin/git-push-pr-merge.sh --repo <worktree> --base <feature_branch> --title "<title>" --body-file /tmp/<project>-pr-body-<N>.md`
+   - `--repo` is not optional here: this script pushes, opens a PR, and on merge
+     runs `checkout` and `branch -D`. Without it those land in the session's
+     start directory, which after a merge is destructive to a tree nobody is watching.
    - This script pushes, creates the PR, waits for the CI checks, merges it, and returns to the feature branch automatically
    - The gate **fails closed**: it merges only on positive evidence that every check is green. Expect each sub-PR to take 1-2 minutes longer than a blind merge, and expect blocks where a red branch used to slip through silently — that is the gate working.
    - **If the script exits non-zero with `STATUS: CI_GATE_BLOCKED`:** the PR was left open. Read the `CI_GATE:` line to see why:

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -34,15 +34,23 @@ land on another session's branch with that session's staged files, exit 0.
 ~/.claude/bin/git-resolve-worktree.sh --issue $ARGUMENTS <hint-if-given>
 ```
 
-The hint is the second word of `$ARGUMENTS`, if given. Omit it and `--issue`
-finds the worktree already on branch `issue-$ARGUMENTS-*` — how a resumed epic is
-picked up without typing a path. With neither, the script prints the current
-worktree, so single-worktree projects behave exactly as before.
+The hint is the second word of `$ARGUMENTS`, if given. It may be the exact name
+of a worktree (an exact name always wins over a longer sibling, so `<repo>` means
+the main tree, not `<repo>-dev1`), any unique substring of its path, or an
+absolute path.
+
+`--issue` is tried when no hint resolves it: it finds the worktree already on
+branch `issue-$ARGUMENTS-*`, which is how a resumed epic is picked up without
+typing a path. On new work that branch does not exist yet — that is normal, and
+the script then reports the current worktree, exactly as with no arguments at
+all. Single-worktree projects therefore never notice this skill has a worktree
+concept.
 
 One absolute path on stdout and exit 0, or nothing on stdout and exit non-zero.
-**On non-zero, stop and show the user its stderr** — it lists the candidates with
-their branches. Never pick one yourself; an autonomous run is exactly where an
-unnoticed wrong guess does the most damage before anyone looks.
+Non-zero means the user's own hint was wrong or ambiguous. **Then stop and show
+them its stderr** — it lists the candidates with their branches. Never pick one
+yourself; an autonomous run is exactly where an unnoticed wrong guess does the
+most damage before anyone looks.
 
 Report the resolved path before the first commit: `Working in: <worktree> [branch]`.
 

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-epic
 description: Automatically implement all sub-issues of an epic in dependency order
-argument-hint: <parent-issue>
+argument-hint: <parent-issue> [worktree]
 user-invocable: true
 ---
 
@@ -11,9 +11,62 @@ Automatically implement all sub-issues of a parent epic in dependency order. Eac
 
 ## Input
 
-The user provides a parent issue number: `$ARGUMENTS`
+The user provides a parent issue number, optionally followed by a worktree hint: `$ARGUMENTS`
 
 This skill runs autonomously — no confirmation stops between sub-issues.
+
+## Worktree
+
+The whole epic runs in ONE worktree, written here as `<worktree>`. Resolve it in
+Phase 0, before anything else, and pass it to every sub-agent.
+
+**Why this is explicit rather than assumed:** your working directory resets
+between every Bash call, and so do exported variables. Nothing carries the target
+path from one command to the next except this instruction, so a bare `git` or a
+repo-relative path silently acts on the directory the session started in. In an
+epic the blast radius is larger than elsewhere: the orchestrator and every
+sub-agent would each fall back to that same start directory, and a commit can
+land on another session's branch with that session's staged files, exit 0.
+
+### Resolving it
+
+```bash
+~/.claude/bin/git-resolve-worktree.sh --issue $ARGUMENTS <hint-if-given>
+```
+
+The hint is the second word of `$ARGUMENTS`, if given. Omit it and `--issue`
+finds the worktree already on branch `issue-$ARGUMENTS-*` — how a resumed epic is
+picked up without typing a path. With neither, the script prints the current
+worktree, so single-worktree projects behave exactly as before.
+
+One absolute path on stdout and exit 0, or nothing on stdout and exit non-zero.
+**On non-zero, stop and show the user its stderr** — it lists the candidates with
+their branches. Never pick one yourself; an autonomous run is exactly where an
+unnoticed wrong guess does the most damage before anyone looks.
+
+Report the resolved path before the first commit: `Working in: <worktree> [branch]`.
+
+### Rules that follow from it
+
+- **git** — always `git -C <worktree> ...`, never a bare `git`
+- **commits** — always `~/.claude/bin/git-commit.sh --repo <worktree> ...`
+- **Read / Edit / Write / Glob / Grep** — absolute paths under `<worktree>` only
+- **project scripts** — `<worktree>/bin/<script>`, not `bin/<script>`;
+  `~/.claude/bin/` scripts are shared and need no prefix
+- **sub-agents** — every prompt states `<worktree>` and the cwd-reset warning; a
+  sub-agent has its own context and inherits none of this
+
+All sub-agents share this one worktree, which is why they are spawned one at a
+time (see "Same-wave issues share one working tree"). Giving each its own
+worktree is a different design, noted there as an alternative — not what
+`<worktree>` means here.
+
+### Test containers
+
+A long-lived test container usually bind-mounts the **main** worktree. Running
+tests through it from a linked worktree tests the wrong source and can write
+files back into a tree nobody is working in. Prefer the project's isolated runner
+where one exists; otherwise record which tree the tests ran against.
 
 **HARD BOUNDARIES — NEVER cross these:**
 - NEVER merge PRs into `develop` or `main` — those merges are always done by the user
@@ -31,7 +84,7 @@ Main session (orchestrator):
 │   │   until #A has fully finished (merged/failed/skipped), even though both
 │   │   are in the same wave and `run_in_background: true` makes it *possible*
 │   │   to fire both at once
-│   ├── Poll progress every 30-45s via /tmp/epic-progress-<N>.txt
+│   ├── Poll progress every 30-45s via /tmp/<project>-epic-progress-<N>.txt
 │   │   └── Report phase + test results to user in real-time
 │   ├── On completion: parse result (SUCCESS/AUDIT_COMPLETE/FAILED)
 │   │   — if neither a result NOR a progress-file update arrives for an
@@ -51,20 +104,28 @@ Main session (orchestrator):
 The main session NEVER implements code itself. It only:
 - Parses the epic and determines execution order
 - Spawns background Task agents for each sub-issue
-- **Monitors progress via `/tmp/epic-progress-<N>.txt` and reports to user**
+- **Monitors progress via `/tmp/<project>-epic-progress-<N>.txt` and reports to user**
 - Handles results (success/failure/skip)
 - Updates the tracking PR
 - Creates bug issues on failure
 
 ## Phase 0: Setup
 
+### Step 0: Resolve the worktree
+
+Resolve `<worktree>` as described in the Worktree section above and report it to
+the user. Everything below assumes it is settled — do it before reading any
+source file or creating any branch.
+
 ### Step 1: Read parent issue
 
 ```bash
-~/.claude/bin/gh-save.sh /tmp/epic-$ARGUMENTS.json issue view $ARGUMENTS --json title,body,labels
+~/.claude/bin/gh-save.sh /tmp/<project>-epic-$ARGUMENTS.json issue view $ARGUMENTS --json title,body,labels
 ```
 
-Use the Read tool to read `/tmp/epic-$ARGUMENTS.json`.
+Use the Read tool to read `/tmp/<project>-epic-$ARGUMENTS.json`. The filename is
+per-project because parallel worktrees mean parallel sessions, and a shared
+`/tmp` name is overwritten by whichever writes last.
 
 ### Step 2: Parse sub-issues and implementation order
 
@@ -87,26 +148,33 @@ Issues within the same wave are implemented sequentially (each needs the branch 
 Copy the project's CLAUDE.md files to a temp location so sub-agents can lazy-load them (avoids embedding 20-30 KB of identical context in every sub-agent prompt):
 
 ```bash
-~/.claude/bin/epic-prepare-context.sh $ARGUMENTS
+~/.claude/bin/epic-prepare-context.sh $ARGUMENTS <worktree>
 ```
+
+Pass `<worktree>` — without it the script reads the session's start directory and
+every sub-agent prompt then points at another tree's CLAUDE.md, which is the
+"foreign architecture" failure the script's own docs warn about.
 
 The script prints the destination prefix on stdout — store it as `context_prefix` (e.g. `/tmp/epic-<project>-632-claude`). On stderr it lists which sections it copied and from which source path, because doc layouts differ per project (`backend/CLAUDE.md` vs `backend/app/CLAUDE.md`, `frontend/CLAUDE.md` vs `src/CLAUDE.md`).
 
 **Only list a section in a sub-agent prompt if the script reported copying it.** A missing context file is harmless — the sub-agent reads the repo's CLAUDE.md itself. Pointing an agent at a path that holds nothing, or worse another project's doc, makes it treat foreign architecture as this project's. The prefix is namespaced per project and epic, and stale destinations are cleared on every run, so cross-project contamination cannot occur through this path.
 
-Also read the root CLAUDE.md yourself to extract the **one-line tech stack summary** and **test/validation commands** — store these as `project_summary` (max 5 lines). This small summary goes into every sub-agent prompt; the full CLAUDE.md files are read by the sub-agent on demand.
+Also read `<worktree>/CLAUDE.md` yourself to extract the **one-line tech stack summary** and **test/validation commands** — store these as `project_summary` (max 5 lines). This small summary goes into every sub-agent prompt; the full CLAUDE.md files are read by the sub-agent on demand.
 
 ### Step 5: Check/create feature branch
 
 ```bash
-git fetch origin
-git branch -a --list "*issue-$ARGUMENTS*"
+git -C <worktree> fetch origin
+git -C <worktree> branch -a --list "*issue-$ARGUMENTS*"
 ```
 
 If the feature branch exists, check it out. Otherwise create it:
 ```bash
-git checkout -b issue-$ARGUMENTS-<description>
+git -C <worktree> checkout -b issue-$ARGUMENTS-<description>
 ```
+
+If `<worktree>` was resolved via `--issue` it is already on that branch — confirm
+with `git -C <worktree> branch --show-current` first.
 
 Store the feature branch name as `feature_branch`.
 
@@ -117,9 +185,9 @@ Find existing tracking PR:
 ~/.claude/bin/find-tracking-pr.sh <repo> $ARGUMENTS
 ```
 
-If no tracking PR exists, create a draft PR against `develop` using the Write tool to write the body to `/tmp/tracking-pr-body.md`, then:
+If no tracking PR exists, create a draft PR against `develop` using the Write tool to write the body to `/tmp/<project>-tracking-pr-body-$ARGUMENTS.md`, then:
 ```bash
-gh pr create --draft --title "<Epic title>" --base develop --body-file /tmp/tracking-pr-body.md
+gh pr create --draft --title "<Epic title>" --base develop --body-file /tmp/<project>-tracking-pr-body-$ARGUMENTS.md
 ```
 
 Store the tracking PR number as `tracking_pr`.
@@ -173,17 +241,17 @@ time is a demonstrated problem for a specific epic.
 Before spawning the sub-agent, ensure the feature branch is up to date:
 
 ```bash
-git checkout <feature_branch>
-git pull origin <feature_branch>
+git -C <worktree> checkout <feature_branch>
+git -C <worktree> pull origin <feature_branch>
 ```
 
 #### Step 2: Fetch issue details and classify
 
 ```bash
-~/.claude/bin/gh-save.sh /tmp/sub-issue-<N>.json issue view <N> --json title,body,labels
+~/.claude/bin/gh-save.sh /tmp/<project>-sub-issue-<N>.json issue view <N> --json title,body,labels
 ```
 
-Use the Read tool to read `/tmp/sub-issue-<N>.json`. Store the issue title, body, and labels.
+Use the Read tool to read `/tmp/<project>-sub-issue-<N>.json`. Store the issue title, body, and labels.
 
 **Classify the issue as `audit` or `implement`:**
 
@@ -229,14 +297,31 @@ Project policies are in these files — read them BEFORE writing code:
 - <context_prefix>-backend.md (backend architecture — read if modifying backend)
 List only the sections Phase 0 reported as copied. Read only the files relevant to your issue. Do NOT skip this step.
 
+## Worktree — read before running anything
+
+All work for this issue happens in `<worktree>`. That is NOT necessarily the
+directory you start in, and your working directory resets to the start directory
+between every Bash call — `cd` cannot fix it once, and exported variables do not
+survive either. Every command must carry the path:
+
+- `git -C <worktree> ...` — never a bare `git`
+- commits: `~/.claude/bin/git-commit.sh --repo <worktree> "..."`
+- Read/Edit/Write/Glob/Grep: absolute paths under `<worktree>` only
+- project scripts: `<worktree>/bin/<script>`; `~/.claude/bin/` scripts are shared
+  and need no prefix
+
+Getting this wrong is silent: both trees are valid checkouts, so a commit aimed
+at the wrong one lands on another session's branch and exits 0.
+
 ## Branch Setup
+- Worktree: <worktree>
 - Feature branch: <feature_branch>
 - Create sub-branch: issue-<N>-<description>
-- Base your work on the feature branch (already checked out)
+- Base your work on the feature branch (already checked out in `<worktree>`)
 - If this issue's body references another sub-issue's output (a column, a
   function signature, a shared module) as already existing, verify that
   assumption against the ACTUAL current state of the feature branch
-  (`git log <feature_branch> --oneline`, `Read`/`Grep` the real file) before
+  (`git -C <worktree> log <feature_branch> --oneline`, `Read`/`Grep` the real file) before
   writing code or tests against it — a same-wave sibling's PR may not have
   merged yet even if its issue number is mentioned as a dependency. If the
   referenced thing genuinely isn't there yet, treat it as blocked and report
@@ -245,8 +330,8 @@ List only the sections Phase 0 reported as copied. Read only the files relevant 
 
 ## Instructions
 
-1. Create and checkout branch: `git checkout -b issue-<N>-<description>`
-2. Read the codebase: use Glob, Grep, Read to understand relevant files.
+1. Create and checkout branch: `git -C <worktree> checkout -b issue-<N>-<description>`
+2. Read the codebase: use Glob, Grep, Read on absolute paths under `<worktree>`.
    **For E2E/Playwright tests:** also read the frontend components you are writing selectors for. Never guess heading text, aria-labels, CSS classes, or DOM structure — look them up in the React/Vue/Svelte source. Grep for the component name, read it, and extract the exact strings and attributes you need for locators.
 3. Implement the changes following the project policies above
 4. Write tests following the Test Quality Policy
@@ -255,21 +340,29 @@ List only the sections Phase 0 reported as copied. Read only the files relevant 
    component + its tests green → commit). **Push right after your FIRST commit**
    so the work exists remotely even if you die mid-task, and keep pushing after
    each later commit:
-   `~/.claude/bin/git-commit.sh "concise descriptive message"` then
-   `git push -u origin issue-<N>-<description>`
+   `~/.claude/bin/git-commit.sh --repo <worktree> "concise descriptive message"` then
+   `git -C <worktree> push -u origin issue-<N>-<description>`
    Multiple commits in the PR are fine and expected — a tidy single commit is not
    worth the risk. A sub-agent can die silently (no error, no FAILED response),
    and everything not yet pushed is lost; agents that had pushed lost nothing,
    agents that had not lost hours of work. This is the single highest-value habit
    in this prompt.
 6. Run ONLY the tests relevant to your changes — NEVER the full test suite:
-   `~/.claude/bin/project-test.sh tests/unit/test_<relevant>/ -v`
+   `~/.claude/bin/project-test.sh <worktree>/tests/unit/test_<relevant>/ -v`
    The full suite and project validation run after all sub-issues are done — not here.
+   If the project runs tests through a long-lived container, check what it
+   bind-mounts first: a container mounting the MAIN worktree tests the wrong
+   source when you are in a linked one, and can write files back into a tree
+   nobody is working in.
 7. If tests fail: fix and retry (up to 3 attempts total)
 8. If tests pass:
-   - Commit any remaining uncommitted work: `~/.claude/bin/git-commit.sh "concise descriptive message"`
-   - Write PR body to /tmp/pr-body.md using the Write tool, then push + PR + merge in one command:
-     `~/.claude/bin/git-push-pr-merge.sh --base <feature_branch> --title "<title>" --body-file /tmp/pr-body.md`
+   - Commit any remaining uncommitted work: `~/.claude/bin/git-commit.sh --repo <worktree> "concise descriptive message"`
+   - Write PR body to /tmp/<project>-pr-body-<N>.md using the Write tool, then push + PR + merge in one command:
+     `~/.claude/bin/git-push-pr-merge.sh --base <feature_branch> --title "<title>" --body-file /tmp/<project>-pr-body-<N>.md`
+   - **This script has no `--repo` flag — it acts on the current directory.** If
+     `<worktree>` is not your start directory, do not run it: report the branch
+     you pushed in your response and let the orchestrator open the PR instead.
+     A blind run here pushes whatever branch the start directory is on.
    - This script pushes, creates the PR, waits for the CI checks, merges it, and returns to the feature branch automatically
    - The gate **fails closed**: it merges only on positive evidence that every check is green. Expect each sub-PR to take 1-2 minutes longer than a blind merge, and expect blocks where a red branch used to slip through silently — that is the gate working.
    - **If the script exits non-zero with `STATUS: CI_GATE_BLOCKED`:** the PR was left open. Read the `CI_GATE:` line to see why:
@@ -282,17 +375,17 @@ List only the sections Phase 0 reported as copied. Read only the files relevant 
 
 ## Auth Impact Check (only include if auth_impact is true)
 This issue changes user status/role/auth fields. BEFORE writing tests:
-1. Read auth/dependencies.py (or equivalent auth guard file)
+1. Read `<worktree>/…/auth/dependencies.py` (or the equivalent auth guard file)
 2. Check which statuses/roles the guard currently allows
 3. Determine: should the NEW status pass the guard or be blocked?
 4. Write a test that verifies this explicitly
 5. If the new status SHOULD pass but the guard blocks it: note this in the PR body as a required follow-up
 
 ## Playwright E2E Test Account Checklist (only for projects using Playwright)
-If this issue creates or modifies Playwright E2E tests that require test accounts, ensure ALL THREE files are in sync:
-1. `tests/e2e/fixtures/test-accounts.ts` — TS fixture with key, email, tier, storageState
-2. `playwright.config.ts` — project entry with testMatch and storageState path
-3. The Python seed script (e.g. `backend/app/scripts/seed_e2e_accounts.py`) — account with matching key, email, tier, and person data
+If this issue creates or modifies Playwright E2E tests that require test accounts, ensure ALL THREE files are in sync (all under `<worktree>`):
+1. `<worktree>/tests/e2e/fixtures/test-accounts.ts` — TS fixture with key, email, tier, storageState
+2. `<worktree>/playwright.config.ts` — project entry with testMatch and storageState path
+3. The Python seed script (e.g. `<worktree>/backend/app/scripts/seed_e2e_accounts.py`) — account with matching key, email, tier, and person data
 Missing any one of these three causes global-setup to fail with a login error at test runtime.
 
 ## HARD BOUNDARIES
@@ -307,7 +400,7 @@ Missing any one of these three causes global-setup to fail with a login error at
 
 ## Progress Reporting
 
-Write your current phase to `/tmp/epic-progress-<N>.txt` using the Write tool at each milestone.
+Write your current phase to `/tmp/<project>-epic-progress-<N>.txt` using the Write tool at each milestone.
 Format (one line per field, only PHASE is required):
 
 PHASE: <milestone-name>
@@ -362,6 +455,15 @@ Body: <full issue body>
 
 ## Project Context
 <project_summary — max 5 lines: tech stack, test command, validation command>
+
+## Worktree — read before running anything
+
+The code to audit lives in `<worktree>`. That is NOT necessarily the directory
+you start in, and your working directory resets between every Bash call. Use
+absolute paths under `<worktree>` for Glob/Grep/Read, and pass `<worktree>` to
+any audit script that takes a target directory. An audit of the wrong tree
+reports on code that is not under review — silently, since both trees are valid
+checkouts.
 
 Project policies are in these files — read them BEFORE starting your audit:
 - <context_prefix>-root.md (project overview, naming conventions)
@@ -419,8 +521,8 @@ You are performing a security AUDIT — your output is a structured report, NOT 
 ```
 
 5. Post the report as an issue comment:
-   - Write report to `/tmp/security-audit-report-<N>.md` using the Write tool
-   - Post: `gh issue comment <N> --body-file /tmp/security-audit-report-<N>.md`
+   - Write report to `/tmp/<project>-security-audit-report-<N>.md` using the Write tool
+   - Post: `gh issue comment <N> --body-file /tmp/<project>-security-audit-report-<N>.md`
 
 ## Tool Rules
 - Use Glob/Grep/Read instead of Bash equivalents (find, grep, cat, head, tail)
@@ -429,7 +531,7 @@ You are performing a security AUDIT — your output is a structured report, NOT 
 
 ## Progress Reporting
 
-Write your current phase to `/tmp/epic-progress-<N>.txt` using the Write tool at each milestone.
+Write your current phase to `/tmp/<project>-epic-progress-<N>.txt` using the Write tool at each milestone.
 Format (one line per field, only PHASE is required):
 
 PHASE: <milestone-name>
@@ -472,7 +574,7 @@ After spawning the background sub-agent:
 
 1. Store the `task_id` from the Task tool response
 2. **Poll every 30-45 seconds** until the agent completes:
-   a. Use the **Read tool** on `/tmp/epic-progress-<N>.txt` (ignore if file doesn't exist yet — agent is still starting)
+   a. Use the **Read tool** on `/tmp/<project>-epic-progress-<N>.txt` (ignore if file doesn't exist yet — agent is still starting)
    b. Parse the `PHASE:`, `DETAIL:`, and `TESTS:` fields
    c. **Report to the user** with a human-readable status message:
       ```
@@ -494,25 +596,27 @@ After spawning the background sub-agent:
 
 A sub-agent can die mid-task without ever sending a completion notification or writing a final progress line — the task ID simply stops resolving via `TaskOutput`. This is distinct from a `FAILED` response (which is an active, intentional report) and distinct from "still working, hasn't hit a milestone yet" (a fresh agent may take several minutes before its first progress-file write). Do not assume either of the other two cases — verify.
 
-**Also watch for a second, different failure signature:** a sub-agent that terminates after only 1-2 tool calls with a vague, self-referential, non-implementing response (e.g. "the agent is running in the background, I'll wait for it to complete") instead of actually doing the work or returning SUCCESS/FAILED. This is not a silent death — it sent a normal completion notification — but it is equally a non-result: no branch, no commits, no PR. Detect it the same way as a silent death (check `git log`/`git status` on the expected branch) since the response text alone is not trustworthy signal that real work happened.
+**Also watch for a second, different failure signature:** a sub-agent that terminates after only 1-2 tool calls with a vague, self-referential, non-implementing response (e.g. "the agent is running in the background, I'll wait for it to complete") instead of actually doing the work or returning SUCCESS/FAILED. This is not a silent death — it sent a normal completion notification — but it is equally a non-result: no branch, no commits, no PR. Detect it the same way as a silent death (the `git -C <worktree> log`/`status` checks in step 2 below) since the response text alone is not trustworthy signal that real work happened.
 
 **When either signature is suspected, before concluding anything is lost:**
 
 1. Call `TaskOutput` with `block: false` on the task ID. If it errors with "No task found", the process is confirmed gone (not just slow).
-2. Check the expected sub-branch for real work, in this order:
-   - `git log <expected-sub-branch> --oneline -5` — did it commit? Compare against the feature branch tip to see if there are new commits.
-   - `git branch -a | grep <N>` — does a remote-tracking branch exist (was anything pushed)?
+2. Check the expected sub-branch for real work, in this order. **Every command
+   here needs `-C <worktree>`** — this section stashes and deletes, so aiming it
+   at the wrong tree destroys work instead of rescuing it:
+   - `git -C <worktree> log <expected-sub-branch> --oneline -5` — did it commit? Compare against the feature branch tip to see if there are new commits.
+   - `git -C <worktree> branch -a | grep <N>` — does a remote-tracking branch exist (was anything pushed)?
    - `~/.claude/bin/gh-save.sh` + `gh pr list --search "<N> in:title"` — was a PR already opened?
-   - `git status --short` on the **currently checked-out branch** — same-wave sub-agents share one working tree (see above), so a dead agent's uncommitted work may be sitting on whatever branch happens to be checked out right now, not necessarily its own sub-branch.
+   - `git -C <worktree> status --short` on the **currently checked-out branch** — same-wave sub-agents share one working tree (see above), so a dead agent's uncommitted work may be sitting on whatever branch happens to be checked out right now, not necessarily its own sub-branch.
 3. **Never discard uncommitted work found this way.** If real, relevant changes are sitting uncommitted:
-   - `git stash push -u -m "orphaned #<N> work from dead sub-agent: <short description>"` — never `git checkout --` or `git clean` a dead agent's edits.
-   - Note the stash reference so it can be referenced when re-spawning.
-4. If a sub-branch has zero commits (identical tip to the feature branch) and nothing was stashed for it, it is safe to delete (`git branch -d <sub-branch>`) before re-spawning — nothing is lost.
+   - `git -C <worktree> stash push -u -m "orphaned #<N> work from dead sub-agent: <short description>"` — never `git checkout --` or `git clean` a dead agent's edits.
+   - Note the stash reference so it can be referenced when re-spawning. A stash belongs to the repository, not the tree, so say which worktree it was taken from.
+4. If a sub-branch has zero commits (identical tip to the feature branch) and nothing was stashed for it, it is safe to delete (`git -C <worktree> branch -d <sub-branch>`) before re-spawning — nothing is lost.
 5. **Re-spawn** with an explicit note in the prompt:
    - State plainly that a previous attempt died and this is a fresh attempt.
-   - If a stash exists, point to it by name/message and say it MAY be inspected for reference (`git stash show -p stash@{N}`) but must not be blindly applied — treat it as unverified, not a starting point to resume from.
+   - If a stash exists, point to it by name/message and say it MAY be inspected for reference (`git -C <worktree> stash show -p stash@{N}`) but must not be blindly applied — treat it as unverified, not a starting point to resume from.
    - If the second failure signature (confused non-response) was the trigger, add an explicit instruction to actually perform the implementation and not just describe or delegate it (see the hardened Response Format instruction below).
-6. After a sub-agent DOES complete successfully following a recovery, verify no stale duplicate files are left on the shared working tree from the dead attempt (`git status --short`) — diff any untracked leftovers against the new committed version; if byte-identical, they are safe to `git clean` away; if they differ, investigate before removing.
+6. After a sub-agent DOES complete successfully following a recovery, verify no stale duplicate files are left on the shared working tree from the dead attempt (`git -C <worktree> status --short`) — diff any untracked leftovers against the new committed version; if byte-identical, they are safe to `git clean` away; if they differ, investigate before removing.
 
 3. **Phase display mapping** (use these human-readable labels):
 
@@ -556,12 +660,13 @@ Parse the sub-agent's response:
 - Record: issue #N → ✅ Complete, PR #X
 
 **On failure** (response contains `FAILED`):
-1. **Create bug issue** — write body to `/tmp/bug-epic-<N>.md`:
+1. **Create bug issue** — write body to `/tmp/<project>-bug-epic-<N>.md`:
 
 ```markdown
 ## Context
 - Epic: #$ARGUMENTS
 - Sub-issue: #<N> — <title>
+- Worktree: <worktree>
 - Feature branch: <feature_branch>
 
 ## Error
@@ -579,14 +684,16 @@ Parse the sub-agent's response:
 ```
 
 ```bash
-gh issue create --title "🐛 [Epic #$ARGUMENTS] Bug: <description>" --label bug --body-file /tmp/bug-epic-<N>.md
+gh issue create --title "🐛 [Epic #$ARGUMENTS] Bug: <description>" --label bug --body-file /tmp/<project>-bug-epic-<N>.md
 ```
 
-2. **Clean up failed branch** (if it was pushed):
+2. **Clean up failed branch** (if it was pushed) — only after step 3 of
+   "Sub-agent Liveness & Recovery" has confirmed nothing uncommitted is left on
+   it. `-D` discards unmerged commits:
 
 ```bash
-git checkout <feature_branch>
-git branch -D issue-<N>-<description>
+git -C <worktree> checkout <feature_branch>
+git -C <worktree> branch -D issue-<N>-<description>
 ```
 
 3. **Mark dependent issues as skipped** — any issue in later waves that depends on this failed issue cannot proceed. Track which issues are skipped and why.
@@ -599,9 +706,9 @@ After each sub-issue (success or failure), update the tracking PR:
 - Add PR link for successful issues
 - Add bug issue link for failures
 
-Write updated body to `/tmp/tracking-pr-update.md`, then:
+Write updated body to `/tmp/<project>-tracking-pr-update-$ARGUMENTS.md`, then:
 ```bash
-gh pr edit <tracking_pr> --body-file /tmp/tracking-pr-update.md
+gh pr edit <tracking_pr> --body-file /tmp/<project>-tracking-pr-update-$ARGUMENTS.md
 ```
 
 ## Phase Final: Verification & Wrap-up
@@ -609,6 +716,23 @@ gh pr edit <tracking_pr> --body-file /tmp/tracking-pr-update.md
 **CRITICAL: NEVER merge PRs into `develop` or `main`. NEVER close the parent issue. NEVER push to `main` or `develop` directly. The tracking PR stays as a draft for the user to review and merge manually.**
 
 **CRITICAL: Phase Final runs ALL verification steps as sub-agents.** The orchestrator's context is depleted after polling waves of sub-issues. Each verification step gets a fresh context window to do its job properly. The orchestrator only collects results and builds the summary.
+
+**Every prompt below opens with this block**, with `<worktree>` filled in. A
+fresh context window inherits none of the Worktree section above, and these
+agents commit to a shared branch:
+
+```
+## Worktree — read before running anything
+
+Everything you verify lives in `<worktree>`. That is NOT necessarily the
+directory you start in, and your working directory resets between every Bash
+call, so `cd` cannot fix it once and exported variables do not survive. Use
+`git -C <worktree> ...`, `~/.claude/bin/git-commit.sh --repo <worktree> ...`,
+absolute paths under `<worktree>` for Read/Edit/Write/Glob/Grep, and
+`<worktree>/bin/<script>` for project scripts. Verifying the wrong tree reports
+green for code that is not under review, and committing to it lands your changes
+on another session's branch — both silently, since both trees are valid checkouts.
+```
 
 ### Step 1: Spawn verification sub-agent — Validation & Tests
 
@@ -627,11 +751,15 @@ Project policies are in these files — read them BEFORE starting:
 ### Step 1: Run project validation
 
 ```bash
-git checkout <feature_branch>
-npm run validate:all
+git -C <worktree> checkout <feature_branch>
 ```
 
-If validation fails, fix issues and commit directly to the feature branch.
+Then run the project's validation chain (e.g. `npm run validate:all`) from
+`<worktree>` — many such chains resolve paths relative to the current directory,
+so running it elsewhere validates the wrong tree.
+
+If validation fails, fix issues and commit directly to the feature branch with
+`~/.claude/bin/git-commit.sh --repo <worktree> "..."`.
 
 **Before committing anything here, check WHAT the validation changed.** Chains
 like `validate:all` typically end in a formatter and a code generator, and both
@@ -641,11 +769,11 @@ instruction above says to commit directly to a shared branch — so it is exactl
 where churn gets committed under a plausible-looking message.
 
 ```bash
-git status --short          # anything you did not touch on purpose?
-git diff --stat             # churn is usually a large diff in a generated file
+git -C <worktree> status --short   # anything you did not touch on purpose?
+git -C <worktree> diff --stat      # churn is usually a large diff in a generated file
 ```
 
-Revert generated-file churn (`git checkout -- <file>`) and commit only real
+Revert generated-file churn (`git -C <worktree> checkout -- <file>`) and commit only real
 fixes. If the diff is genuine (you changed a backend schema), regenerate
 deliberately and say so in the commit message.
 
@@ -661,7 +789,7 @@ Instead, run only test files related to files changed by the epic:
 
 1. Get changed source files (not tests):
 ```bash
-git diff develop..<feature_branch> --name-only -- '*.py' '*.ts' '*.tsx' | grep -v test
+git -C <worktree> diff develop..<feature_branch> --name-only -- '*.py' '*.ts' '*.tsx' | grep -v test
 ```
 
 2. For each changed source file, find related test files using Glob/Grep:
@@ -669,9 +797,9 @@ git diff develop..<feature_branch> --name-only -- '*.py' '*.ts' '*.tsx' | grep -
    - `backend/app/api/foo.py` → `backend/tests/**/test_foo*`
    - `frontend/src/pages/FooPage.tsx` → `frontend/src/**/__tests__/Foo*`
 
-3. Run ONLY those test files with a generous timeout (tests may take minutes per file):
+3. Run ONLY those test files with a generous timeout (tests may take minutes per file), as absolute paths under `<worktree>`:
 ```bash
-~/.claude/bin/project-test.sh <test-file-1> <test-file-2> ... -v
+~/.claude/bin/project-test.sh <worktree>/<test-file-1> <worktree>/<test-file-2> ... -v
 ```
 Use `timeout: 600000` (10 minutes) on the Bash call.
 
@@ -682,7 +810,7 @@ Use `timeout: 600000` (10 minutes) on the Bash call.
 
 ### Step 3: Report
 
-Write progress to `/tmp/epic-verify-validation.txt`:
+Write progress to `/tmp/<project>-epic-verify-validation-$ARGUMENTS.txt`:
 
 PHASE: RUNNING_VALIDATION / RUNNING_TESTS / FIXING / DONE
 DETAIL: <what's happening>
@@ -713,7 +841,7 @@ Project policies are in these files — read them BEFORE starting:
 ### Step 0: Find the project's own commands
 
 This step is project-specific — never guess a container name or a script path.
-Read the root CLAUDE.md and the compose file to establish, before running
+Read `<worktree>/CLAUDE.md` and the compose file to establish, before running
 anything:
 
 - `api_container` — the service/container running the API (`docker compose ps`,
@@ -727,12 +855,20 @@ anything:
 If a project defines none of these, skip the steps below that depend on it and
 report SKIP with the reason. A step that cannot be run is not a failure.
 
+**Also establish which tree the containers actually serve.** Compose files
+commonly bind-mount the MAIN worktree, so a stack started from a linked one runs
+the wrong source and a restart can write files back into a tree nobody is working
+in. Check the mount paths in the compose file against `<worktree>`. If they point
+elsewhere, say so in your report rather than reporting a green runtime for code
+that is not under review — the containers are evidence about whichever tree they
+mount, not about this one.
+
 ### Step 1: Rebuild containers if dependencies changed
 
 Check if dependency files were modified:
 
 ```bash
-git diff develop..<feature_branch> --name-only | grep -E "(package\.json|package-lock\.json|requirements\.txt|pyproject\.toml|uv\.lock)"
+git -C <worktree> diff develop..<feature_branch> --name-only | grep -E "(package\.json|package-lock\.json|requirements\.txt|pyproject\.toml|uv\.lock)"
 ```
 
 If any dependency file changed, run `<restart_cmd>` — a dependency change needs
@@ -774,7 +910,7 @@ If the project has no such script, report SKIP.
 
 ### Step 6: Report
 
-Write progress to `/tmp/epic-verify-runtime.txt`:
+Write progress to `/tmp/<project>-epic-verify-runtime-$ARGUMENTS.txt`:
 
 PHASE: REBUILDING / HEALTH_CHECK / SMOKE_TEST / MIGRATION_CHECK / LOGIN_TEST / DONE
 DETAIL: <what's happening>
@@ -805,24 +941,25 @@ You are checking that new user statuses or roles introduced by epic #<epic_numbe
 
 Search the feature branch diff for new statuses/roles:
 ```bash
-git diff develop..<feature_branch>
+git -C <worktree> diff develop..<feature_branch>
 ```
 Look for: enum additions (Python `class ...Status`, `ALTER TYPE ADD VALUE`), new role constants, new permission levels.
 
 ### Step 2: Verify auth guards
 
 For each new status/role found:
-- Read the auth guard (e.g., `auth/dependencies.py`)
+- Read the auth guard (e.g., `<worktree>/…/auth/dependencies.py`)
 - Check if the guard explicitly handles the new status
 - Write a targeted test that creates a user with the new status and verifies expected behavior
 
 ### Step 3: Run tests
 
 ```bash
-~/.claude/bin/project-test.sh <test-file> -v
+~/.claude/bin/project-test.sh <worktree>/<test-file> -v
 ```
 
-If tests fail: fix on the feature branch and commit.
+If tests fail: fix on the feature branch and commit with
+`~/.claude/bin/git-commit.sh --repo <worktree> "..."`.
 If no new statuses/roles found: report SKIP.
 
 ## Response Format
@@ -858,7 +995,7 @@ Based on the epic scope, classify what area was touched:
 
 ### Step 2: Write a targeted smoke test
 
-Create `tests/e2e/<epic-domain>-smoke.spec.ts`
+Create `<worktree>/tests/e2e/<epic-domain>-smoke.spec.ts`
 
 Read the actual frontend components you are writing selectors for — never guess headings, aria-labels, or DOM structure.
 
@@ -869,6 +1006,9 @@ Keep it minimal:
 
 ### Step 3: Run the smoke test
 
+Run it from `<worktree>` — Playwright resolves its config and test paths relative
+to the current directory, so running it elsewhere tests the wrong tree:
+
 ```bash
 npx playwright test tests/e2e/<epic-domain>-smoke.spec.ts --project=<project-name>
 ```
@@ -877,7 +1017,8 @@ If tests fail: fix and retry once.
 
 ### Step 4: Commit the smoke test
 
-The smoke test is a permanent artefact — commit it to the feature branch.
+The smoke test is a permanent artefact — commit it to the feature branch:
+`~/.claude/bin/git-commit.sh --repo <worktree> "..."`.
 
 ## Response Format
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -33,16 +33,23 @@ land on another session's branch, carrying that session's staged files, and exit
 ~/.claude/bin/git-resolve-worktree.sh --issue $ARGUMENTS <hint-if-given>
 ```
 
-The hint is the second word of `$ARGUMENTS`, if the user gave one. Omit it and
-`--issue` finds the worktree already on branch `issue-$ARGUMENTS-*` — how resumed
-work is picked up without anyone typing a path. With neither, the script prints
-the current worktree, so single-worktree projects behave exactly as before.
+The hint is the second word of `$ARGUMENTS`, if the user gave one. It may be the
+exact name of a worktree (an exact name always wins over a longer sibling, so
+`<repo>` means the main tree, not `<repo>-dev1`), any unique substring of its
+path, or an absolute path.
+
+`--issue` is tried when no hint resolves it: it finds the worktree already on
+branch `issue-$ARGUMENTS-*`, which is how resumed work is picked up without
+anyone typing a path. On new work that branch does not exist yet — that is
+normal, and the script then simply reports the current worktree, exactly as it
+does with no arguments at all. Single-worktree projects therefore never notice
+this skill has a worktree concept.
 
 The script prints one absolute path and exits 0, or prints nothing to stdout and
-exits non-zero. **On non-zero, stop and show the user its stderr** — it lists the
-candidates with their branches. Do not pick one yourself and do not fall back to
-the current directory; an unresolved worktree is a question for the user, not a
-guess to make.
+exits non-zero. Non-zero means the user's own hint was wrong or ambiguous.
+**Then stop and show them its stderr** — it lists the candidates with their
+branches. Do not pick one yourself and do not fall back to the current directory;
+an unresolved hint is a question for the user, not a guess to make.
 
 Then state the resolved path to the user, before the first commit:
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
 description: Implement a GitHub issue with automated PR creation
-argument-hint: <issue-number>
+argument-hint: <issue-number> [worktree]
 user-invocable: true
 ---
 
@@ -11,9 +11,66 @@ Implement GitHub issue with automated workflow.
 
 ## Input
 
-The user provides an issue number: `$ARGUMENTS`
+The user provides an issue number, optionally followed by a worktree hint: `$ARGUMENTS`
 
-MUST use ~/.claude/bin/git-find-base-branch for base branch detection for the PR.
+MUST use `~/.claude/bin/git-find-base-branch <worktree>` for base branch detection for the PR.
+
+## Worktree
+
+Everything below operates on ONE worktree, written here as `<worktree>`. Resolve
+it first, in Phase 1, before reading or changing anything.
+
+**Why this is explicit rather than assumed:** your working directory resets
+between every Bash call, and so do exported variables. Nothing carries the target
+path from one command to the next except this instruction. A repo-relative path
+or a bare `git` therefore silently acts on the directory the session started in —
+which is the right tree only by coincidence. The damage is quiet: a commit can
+land on another session's branch, carrying that session's staged files, and exit 0.
+
+### Resolving it
+
+```bash
+~/.claude/bin/git-resolve-worktree.sh --issue $ARGUMENTS <hint-if-given>
+```
+
+The hint is the second word of `$ARGUMENTS`, if the user gave one. Omit it and
+`--issue` finds the worktree already on branch `issue-$ARGUMENTS-*` — how resumed
+work is picked up without anyone typing a path. With neither, the script prints
+the current worktree, so single-worktree projects behave exactly as before.
+
+The script prints one absolute path and exits 0, or prints nothing to stdout and
+exits non-zero. **On non-zero, stop and show the user its stderr** — it lists the
+candidates with their branches. Do not pick one yourself and do not fall back to
+the current directory; an unresolved worktree is a question for the user, not a
+guess to make.
+
+Then state the resolved path to the user, before the first commit:
+
+```
+Working in: <worktree>  [branch]
+```
+
+### Rules that follow from it
+
+Apply these everywhere below, wherever a command touches the repository:
+
+- **git** — always `git -C <worktree> ...`, never a bare `git`
+- **commits** — always `~/.claude/bin/git-commit.sh --repo <worktree> ...`
+- **Read / Edit / Write / Glob / Grep** — absolute paths under `<worktree>` only,
+  never repo-relative ones
+- **project scripts** — run `<worktree>/bin/<script>`, not `bin/<script>`;
+  `~/.claude/bin/` scripts are unaffected, they are the same files for every tree
+- **sub-agents** — pass `<worktree>` in the prompt; a sub-agent has its own
+  context and inherits none of this
+
+### Test containers
+
+A long-lived test container usually bind-mounts the **main** worktree. Run tests
+through it from a linked worktree and you test the wrong source, and it may write
+files back into a tree the user never touched. Where the project offers an
+isolated runner (a disposable container, a per-worktree compose project), use it
+and say so; where it does not, note in the PR body which tree the tests actually
+ran against.
 
 ## Tool Rules
 
@@ -25,13 +82,16 @@ MUST use ~/.claude/bin/git-find-base-branch for base branch detection for the PR
 
 ## Phase 1: Discovery & Planning
 
-1. Fetch issue details: `~/.claude/bin/gh-save.sh /tmp/issue-$ARGUMENTS.json issue view $ARGUMENTS --json title,body,labels`, then use the Read tool to read it
+0. **Resolve `<worktree>`** as described in the Worktree section above, and report
+   it to the user. Every path and git command in the phases below assumes this is
+   settled — do it before reading any source file, or you will read the wrong one.
+1. Fetch issue details: `~/.claude/bin/gh-save.sh /tmp/<project>-issue-$ARGUMENTS.json issue view $ARGUMENTS --json title,body,labels`, then use the Read tool to read it
 2. **Check for linked Sentry issues** in the issue body:
    * Look for Sentry issue references — short IDs of the form `<PROJECT>-<PLATFORM>-<SUFFIX>`, Sentry URLs, or "Sentry Issues" sections
    * If found, note the Sentry issue IDs — these will be referenced in commit messages and the PR body for automatic resolution
    * Store as a list, e.g. `SENTRY_ISSUES=["MYAPP-BACKEND-G", "MYAPP-BACKEND-H"]`
-3. Read AND verify understanding of existing code:
-   * Read all CLAUDE.md files (root, frontend, backend if they exist)
+3. Read AND verify understanding of existing code (all paths absolute, under `<worktree>`):
+   * Read all CLAUDE.md files (`<worktree>/CLAUDE.md`, and the frontend/backend ones if they exist)
    * Read the ACTUAL source files you plan to modify
    * Check what attributes/methods ACTUALLY exist on models you'll use
    * Find existing patterns for similar functionality (grep/search)
@@ -55,7 +115,10 @@ STOP HERE and ask for confirmation before proceeding to implementation.
 
 ## Phase 2: Branch & TDD Implementation
 
-1. Create and checkout branch: `issue-$ARGUMENTS-<descriptive-label>`
+1. Create and checkout branch in the target tree:
+   `git -C <worktree> checkout -b issue-$ARGUMENTS-<descriptive-label>`
+   If `<worktree>` was resolved via `--issue` it is already on that branch — check
+   with `git -C <worktree> branch --show-current` before creating it.
 2. Before writing new code, verify your assumptions:
    * If using model attributes, confirm they exist: `grep "attribute_name" models.py`
    * If importing classes, confirm they exist: `python -c "from module import Class"`
@@ -79,8 +142,11 @@ STOP HERE and ask for confirmation before proceeding to implementation.
 3. **REFACTOR — Clean up, then commit**
    * Remove duplication, improve naming if needed
    * Run tests again to confirm nothing broke
-   * Commit: `~/.claude/bin/git-commit.sh "descriptive message for this step"`
-   * If SENTRY_ISSUES were found in Phase 1, add `Fixes <ID>` to the **final commit only** (the last step before PR creation), e.g.: `~/.claude/bin/git-commit.sh "final step description" "" "Fixes MYAPP-BACKEND-G" "Fixes MYAPP-BACKEND-H"`
+   * Stage and commit in the target tree — `--repo` is not optional, without it
+     the commit is judged against the session's start directory:
+     `git -C <worktree> add <paths>` then
+     `~/.claude/bin/git-commit.sh --repo <worktree> "descriptive message for this step"`
+   * If SENTRY_ISSUES were found in Phase 1, add `Fixes <ID>` to the **final commit only** (the last step before PR creation), e.g.: `~/.claude/bin/git-commit.sh --repo <worktree> "final step description" "" "Fixes MYAPP-BACKEND-G" "Fixes MYAPP-BACKEND-H"`
 
 4. **Move on — Focus shifts to the next step**
    * Do not revisit completed steps unless a later test breaks them
@@ -145,9 +211,10 @@ churn you then have to revert and risk committing. Use the check-only variant
 ### Step 1: Gather context for the sub-agent
 
 Before spawning, collect:
-- `base_branch` — from `~/.claude/bin/git-find-base-branch`
+- `base_branch` — from `~/.claude/bin/git-find-base-branch <worktree>`
 - `acceptance_criteria` — the AC list parsed in Phase 1 (or "none" if not found)
-- `modified_files` — `~/.claude/bin/git-diff-base.sh <base-branch>`
+- `modified_files` — `~/.claude/bin/git-diff-base.sh --repo <worktree> <base-branch>`
+- `worktree` — the absolute path resolved in Phase 1
 - `has_backend_endpoints` — true if any modified file matches `**/api/**`, `**/routes/**`, `**/endpoints/**`
 - `has_schema_changes` — true if any modified file matches `**/schemas/**`, `**/models/**`, `**/migrations/**`
 
@@ -163,16 +230,35 @@ Run each step below and report results in the structured format at the end.
 
 ## Context
 - Issue: #$ARGUMENTS
+- Worktree: <worktree>
 - Base branch: <base_branch>
 - Modified files: <modified_files>
 - Acceptance criteria: <acceptance_criteria or "none parsed">
 - Has backend endpoints: <true/false>
 - Has schema changes: <true/false>
 
+## Worktree — read before running anything
+
+The work under verification lives in `<worktree>`. That is NOT necessarily the
+directory you start in, and your working directory resets to the start directory
+between every Bash call, so `cd` cannot fix it once and exported variables do not
+survive either. Every command must carry the path:
+
+- `git -C <worktree> ...` — never a bare `git`
+- `~/.claude/bin/git-diff-base.sh --repo <worktree> <base_branch>`
+- `~/.claude/bin/git-find-base-branch <worktree>`
+- commits (if a fix needs one): `~/.claude/bin/git-commit.sh --repo <worktree> "..."`
+- Read/Edit/Write/Glob/Grep: absolute paths under `<worktree>` only
+- project scripts: `<worktree>/bin/<script>`; `~/.claude/bin/` scripts are shared
+  and need no prefix
+
+A verification run against the wrong tree reports green for code that is not the
+code under review — silently, because both trees are valid checkouts.
+
 Project policies — read these BEFORE verifying:
-- ./CLAUDE.md (project root)
-- ./frontend/CLAUDE.md (if frontend changes)
-- ./backend/app/CLAUDE.md or ./backend/CLAUDE.md (if backend changes)
+- <worktree>/CLAUDE.md (project root)
+- <worktree>/frontend/CLAUDE.md (if frontend changes)
+- <worktree>/backend/app/CLAUDE.md or <worktree>/backend/CLAUDE.md (if backend changes)
 
 ## Tool Rules
 - Use Glob/Grep/Read instead of Bash equivalents (find, grep, cat, head, tail)
@@ -184,16 +270,22 @@ Project policies — read these BEFORE verifying:
 
 ### Step A: Targeted tests
 Run ONLY tests relevant to the modified files — never the full suite:
-`~/.claude/bin/project-test.sh tests/path/to/your_test.py -v`
+`~/.claude/bin/project-test.sh <worktree>/tests/path/to/your_test.py -v`
 If any test fails, fix at root cause and re-run.
 
+If the project runs tests through a long-lived container, check what that
+container bind-mounts before trusting the result: it commonly mounts the MAIN
+worktree, so a run started from a linked one tests the wrong source and can write
+files back into a tree nobody is working in. Prefer the project's isolated runner
+where it has one; otherwise report which tree the tests actually ran against.
+
 ### Step B: Project validation
-Check for one of: `npm run validate:all`, `make validate`, `./validate.sh`.
-If found, run it. If backend schemas changed, ensure OpenAPI is regenerated.
-Fix any errors before proceeding.
+Check for one of: `npm run validate:all`, `make validate`, `./validate.sh` — in
+`<worktree>`, and run it from there. If backend schemas changed, ensure OpenAPI is
+regenerated. Fix any errors before proceeding.
 
 ### Step C: Integration verification (conditional)
-Check the project's CLAUDE.md for an **Integration Verification** section.
+Check `<worktree>/CLAUDE.md` for an **Integration Verification** section.
 If it exists AND modified files match a trigger pattern, run the defined steps.
 Otherwise skip.
 
@@ -208,14 +300,14 @@ For UNVERIFIED items: write a test if testable, else flag for manual review.
 
 ### Step E: Self-review (max 2 fix iterations)
 Run the `/review` analysis on the branch diff:
-`~/.claude/bin/git-diff-base.sh --patch <base-branch>`
+`~/.claude/bin/git-diff-base.sh --repo <worktree> --patch <base-branch>`
 
 If findings with severity > INFO:
 - Fix automatically, re-run Step A, re-run review
 - Max 2 iterations — remaining findings go into the PR body as "Known Issues"
 
 ### Step F: API smoke test (skip if has_backend_endpoints = false)
-First establish the project's own names — read the root CLAUDE.md and the
+First establish the project's own names — read `<worktree>/CLAUDE.md` and the
 compose file for the API container, the restart command and the login helper.
 Never guess a container name or script path; if the project defines none, skip
 this step and report SKIP with the reason.
@@ -267,8 +359,11 @@ Before proceeding to PR creation:
 
 ## Phase 4: PR Creation
 
-1. Determine base branch: `~/.claude/bin/git-find-base-branch`
-2. Write PR body to `/tmp/pr-body.md` using the Write tool. Include:
+1. Determine base branch: `~/.claude/bin/git-find-base-branch <worktree>`
+2. Write PR body to `/tmp/<project>-pr-body-$ARGUMENTS.md` using the Write tool —
+   a per-project, per-issue name, because parallel worktrees mean parallel
+   sessions and a shared `/tmp/pr-body.md` gets overwritten by whichever writes
+   last. Include:
    - `Closes #$ARGUMENTS`
    - Implementation summary
    - Test checklist (test counts from the verification sub-agent's TESTS line)
@@ -276,8 +371,12 @@ Before proceeding to PR creation:
    - If `AC_UNVERIFIED` from Phase 3 is not "none": add a `## Manual Review Needed` section listing the UNVERIFIED criteria
    - If SENTRY_ISSUES were found in Phase 1, add a `## Sentry` section: `Resolves: MYAPP-BACKEND-G, MYAPP-BACKEND-H`
 3. Push + create PR in one command:
-   `~/.claude/bin/git-push-pr-merge.sh --base <base-branch> --title "<concise description>" --body-file /tmp/pr-body.md --no-merge`
+   `~/.claude/bin/git-push-pr-merge.sh --base <base-branch> --title "<concise description>" --body-file /tmp/<project>-pr-body-$ARGUMENTS.md --no-merge`
    `--no-merge` means the CI gate is skipped — the PR is left open for human review regardless of check status
+   **This script has no `--repo` flag: it acts on the current directory.** When
+   `<worktree>` is not the session's start directory, confirm the branch first
+   (`git -C <worktree> branch --show-current`) and ask the user to run it from
+   `<worktree>`, rather than pushing whatever branch the start directory is on.
 4. Return PR URL for review
 
 ## Phase 5: Epic Tracking Update (automatic, if applicable)
@@ -320,8 +419,8 @@ If no row exists for this issue, add one:
 
 **3c. Write updated body and apply:**
 ```bash
-# Write updated body to /tmp/pr_body.md using the Write tool
-gh pr edit [tracking-pr-number] --body-file /tmp/pr_body.md
+# Write updated body to /tmp/<project>-tracking-pr-body-$ARGUMENTS.md using the Write tool
+gh pr edit [tracking-pr-number] --body-file /tmp/<project>-tracking-pr-body-$ARGUMENTS.md
 ```
 
 ### Step 4: Confirm

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -371,12 +371,8 @@ Before proceeding to PR creation:
    - If `AC_UNVERIFIED` from Phase 3 is not "none": add a `## Manual Review Needed` section listing the UNVERIFIED criteria
    - If SENTRY_ISSUES were found in Phase 1, add a `## Sentry` section: `Resolves: MYAPP-BACKEND-G, MYAPP-BACKEND-H`
 3. Push + create PR in one command:
-   `~/.claude/bin/git-push-pr-merge.sh --base <base-branch> --title "<concise description>" --body-file /tmp/<project>-pr-body-$ARGUMENTS.md --no-merge`
+   `~/.claude/bin/git-push-pr-merge.sh --repo <worktree> --base <base-branch> --title "<concise description>" --body-file /tmp/<project>-pr-body-$ARGUMENTS.md --no-merge`
    `--no-merge` means the CI gate is skipped — the PR is left open for human review regardless of check status
-   **This script has no `--repo` flag: it acts on the current directory.** When
-   `<worktree>` is not the session's start directory, confirm the branch first
-   (`git -C <worktree> branch --show-current`) and ask the user to run it from
-   `<worktree>`, rather than pushing whatever branch the start directory is on.
 4. Return PR URL for review
 
 ## Phase 5: Epic Tracking Update (automatic, if applicable)

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -13,7 +13,7 @@ Implement GitHub issue with automated workflow.
 
 The user provides an issue number, optionally followed by a worktree hint: `$ARGUMENTS`
 
-MUST use `~/.claude/bin/git-find-base-branch <worktree>` for base branch detection for the PR.
+MUST use `~/.claude/bin/git-find-base-branch --repo <worktree>` for base branch detection for the PR.
 
 ## Worktree
 
@@ -211,7 +211,7 @@ churn you then have to revert and risk committing. Use the check-only variant
 ### Step 1: Gather context for the sub-agent
 
 Before spawning, collect:
-- `base_branch` — from `~/.claude/bin/git-find-base-branch <worktree>`
+- `base_branch` — from `~/.claude/bin/git-find-base-branch --repo <worktree>`
 - `acceptance_criteria` — the AC list parsed in Phase 1 (or "none" if not found)
 - `modified_files` — `~/.claude/bin/git-diff-base.sh --repo <worktree> <base-branch>`
 - `worktree` — the absolute path resolved in Phase 1
@@ -246,7 +246,7 @@ survive either. Every command must carry the path:
 
 - `git -C <worktree> ...` — never a bare `git`
 - `~/.claude/bin/git-diff-base.sh --repo <worktree> <base_branch>`
-- `~/.claude/bin/git-find-base-branch <worktree>`
+- `~/.claude/bin/git-find-base-branch --repo <worktree>`
 - commits (if a fix needs one): `~/.claude/bin/git-commit.sh --repo <worktree> "..."`
 - Read/Edit/Write/Glob/Grep: absolute paths under `<worktree>` only
 - project scripts: `<worktree>/bin/<script>`; `~/.claude/bin/` scripts are shared
@@ -359,7 +359,7 @@ Before proceeding to PR creation:
 
 ## Phase 4: PR Creation
 
-1. Determine base branch: `~/.claude/bin/git-find-base-branch <worktree>`
+1. Determine base branch: `~/.claude/bin/git-find-base-branch --repo <worktree>`
 2. Write PR body to `/tmp/<project>-pr-body-$ARGUMENTS.md` using the Write tool —
    a per-project, per-issue name, because parallel worktrees mean parallel
    sessions and a shared `/tmp/pr-body.md` gets overwritten by whichever writes


### PR DESCRIPTION
Closes #58

Gives the implement skills an explicit worktree target, so work can no longer land silently in the wrong tree.

## Why

An agent's working directory resets between every Bash call, and so do exported variables. In a repo with linked worktrees, nothing carries "work in that tree" from one command to the next, so a bare `git` or a repo-relative path quietly acts on whichever directory the session started in. The failure is silent: a commit can land on another session's branch, carrying that session's staged files, and exit 0.

The skill instruction is the only thing in this system that stays in context across commands, so that is where the target path lives.

## What changed

**`bin/git-resolve-worktree.sh`** (new) — turns a short hint into one absolute path:

- `--issue N` matches branch `issue-N-<slug>`, anchored on the trailing dash so `--issue 7` does not match `issue-77-*`. Resumed work needs no argument at all.
- A case-insensitive substring of a worktree path, or an absolute path (validated against this repository's worktree list, not trusted on sight).
- Zero or several matches: exit non-zero, candidates and their branches to stderr, **nothing on stdout** so a `$(...)` capture cannot become a guess.
- No argument and nothing to detect: prints the current worktree. Single-worktree projects are unaffected.

**`bin/git-find-base-branch`** — optional repo argument. Without it the skills would keep reporting the base branch of the wrong tree at all three call sites.

**`skills/implement/SKILL.md`, `skills/implement-epic/SKILL.md`** — one `## Worktree` section each defining the rules (`git -C`, `--repo`, absolute paths, `<worktree>/bin/`), resolved and announced in the first phase, then applied at every call site. Sub-agent prompts carry the path plus the cwd-reset warning, since a fresh context inherits none of it.

## Three latent bugs found and fixed while threading this through

Both are the same class as the issue: a shared resource silently resolving to the wrong thing. Both are fixed here, not merely noted.

**1. `epic-prepare-context.sh` was called without its `[project-dir]` argument.** The script copies the project's CLAUDE.md files to `/tmp` for sub-agents to read; without the argument it reads the session's start directory. In a linked-worktree run, every sub-agent prompt would then point at another tree's CLAUDE.md — the "foreign architecture" failure the script's own header warns about, where an agent treats another project's conventions as this project's. Now called as `epic-prepare-context.sh $ARGUMENTS <worktree>`.

**2. Shared `/tmp` filenames across concurrent sessions.** Eleven fixed names (`/tmp/pr-body.md`, `/tmp/epic-progress-<N>.txt`, `/tmp/tracking-pr-update.md`, …) were shared by every project and every session. Parallel worktrees are precisely parallel sessions, so two runs would overwrite each other's PR body or progress file — one agent then reads the other's content and acts on it. All are now namespaced as `/tmp/<project>-<purpose>-<nr>`, matching the convention already used elsewhere in this repo.

## Tests

42/42 passing:

- `bin/tests/test-git-resolve-worktree.sh` — 36 assertions against a throwaway repo with real linked worktrees. Nothing mocked.
- `bin/test-git-find-base-branch.sh` — 6, up from 3. The new cases run from a linked worktree and assert both directions, so they cannot pass by always reporting the same branch.

Verified by mutation, not just by green:

| Mutation | Tests that fail |
|---|---|
| Ambiguity picks the first match | 6 |
| Trailing-dash anchor dropped | 2 |
| Case-insensitivity removed | 2 |
| Path accepted without validation | 1 |
| **Silent fallback to current worktree on no match** | **8** |

The last one is the bug from the issue; it is caught eight different ways.

A/B on `git-find-base-branch`: the three new cases fail against `main`'s version and pass on this branch, while the three pre-existing cases pass on both.

`shellcheck` clean on all four changed scripts. `git-resolve-worktree.sh` also smoke-tested against this repository's real worktrees, including a detached one.

**3. `git-push-pr-merge.sh` had no `--repo` flag and acted on the current directory.** The most dangerous of the three: it pushes a branch, opens a PR, and on merge runs `checkout` plus `branch -D`. Aimed at the session's start directory instead of the work tree, that pushes the wrong branch and then deletes a branch in a tree nobody is watching. It now takes `--repo`, validating the path and refusing before pushing rather than falling back to the caller's directory. One `cd` covers all six call sites, including `gh`, which derives its repository from the working directory the same way git does. Both skills now pass it.

## Tests for the `--repo` flag

`bin/test-git-push-pr-merge.sh` grows from 13 scenarios to 14 (56 → 59 assertions). The new one runs the script **from a different worktree than the target**, with the two on different branches, so an ignored flag surfaces the caller's branch and fails:

- pushes the target's branch, and the caller's branch never appears in the output
- the base-equals-current guard judges the target tree, not the caller's
- a bad `--repo` path exits non-zero and pushes nothing
- **without** `--repo` the old behaviour is unchanged (the caller's tree is used)

Mutation-verified: accepting `--repo` but ignoring it — exactly the "paper over it" version — fails 4 of these. The 13 pre-existing CI-gate scenarios still pass.

## `--repo` as a convention

With three scripts now taking a worktree path, the interfaces had drifted apart: four used `--repo`, while `git-find-base-branch` (added in this PR) and `git-verify.sh` took a positional path. `--repo` is now the single spelling for every script that selects a git **worktree**:

`git-commit.sh` · `git-diff-base.sh` · `git-push-pr-merge.sh` · `git-verify.sh` · `git-find-base-branch`

The positional form still works on both scripts that had it, so no existing call breaks. Naming the same tree twice is fine; naming two different ones is now an error rather than a silent pick.

Scripts taking a *scan path* rather than a worktree keep their positional argument (`deps-audit.sh`, `secret-scan.sh`, `env-audit.sh`, `docker-audit.sh`, `docker-health-check.sh`, `epic-prepare-context.sh`). `secret-scan.sh ~/Downloads` is meaningful; calling that `--repo` would misdescribe it.

**Not `-C`, despite the resemblance to `git -C`.** That flag means "run as if git was started in `<path>`" — a chdir, which is why `git -C ""` is a no-op and multiple `-C`s stack. These scripts do something narrower: select a worktree and refuse a path that is not one. Same letter, different semantics is the wrong kind of consistency, and one character buys nothing when the caller is an agent rather than a typist.

Two latent bugs surfaced while doing this, both in `git-verify.sh`'s catch-all argument branch:

- `--repo` already "worked" by accident — the catch-all took the literal word `--repo` as the path, then the next argument overwrote it. Right answer, wrong reason.
- Any unrecognised argument silently became the target directory. A mistyped flag pointed the script at a path instead of complaining.

New `bin/tests/test-git-verify.sh` (18 assertions) and 6 more in `bin/test-git-find-base-branch.sh` (6 → 12) cover both spellings in both directions, bad paths, conflicting targets, and unknown options. All four guards are mutation-verified. One of those probes caught a weak test of mine: asserting only on the exit code passed even with the guard removed, because `cd --nope` fails too — the assertion now checks the message that distinguishes them.

## Out of scope

Per the issue: `/finish`, `/bug`, `/decompose`, `/extend`, and a PreToolUse guard hook.
